### PR TITLE
添加CoatlAerospace（ProbePlus）汉化

### DIFF
--- a/GameData/0000Tinygrox_CNPatches/Coatl Aerospace/ProbePlus-RO-Patches.cfg
+++ b/GameData/0000Tinygrox_CNPatches/Coatl Aerospace/ProbePlus-RO-Patches.cfg
@@ -1,0 +1,1074 @@
+//ProbePlus的RO的汉化文件
+
+//Surveyor Lander Core
+@PART[ca_landv_core]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号着陆器核心
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号登陆器的主要组件。包含三个着陆腿和用于三个微调发动机及其姿态控制系统（需单独购买）的推进剂。正常着陆操作还需要一个固体燃料反推引擎。
+}
+
+//Surveyor Orbiter Core
+@PART[ca_landv_orbiter_core]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号轨道器核心
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号登陆器的轨道器版本，不包含着陆所需的硬件。
+}
+
+//Surveyor Planar Antenna and Solar Array
+@PART[ca_landv_hga]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号平板天线和太阳能阵列
+    @manufacturer = 休斯飞机公司
+    @description = 勘测者号登陆器使用的高增益天线和太阳能阵列。
+}
+
+//Surveyor Low Gain Antenna (LGA)
+@PART[ca_landv_omni]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号低增益天线（LGA）
+    @manufacturer = 休斯飞机公司
+    @description = 这是用于勘测者号登陆器和轨道器的全向低增益天线。安装两个这样的天线可以作为主平面天线的备份。
+}
+
+//Surveyor Orbiter High Gain Antenna
+@PART[ca_landv_orbiter_HGA]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号轨道器高增益天线
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号登陆器的平面高增益天线的基本型号，经过修改后用于轨道器版本。该版本不包含太阳能电池板。
+}
+
+//Surveyor Battery Pack
+@PART[ca_landv_battery]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号电池包
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号登陆器和轨道器的主电池包。\n\n容量：<color=orange>3650 Wh</color>。
+}
+
+//Surveyor Orbiter Solar Array Wing
+@PART[ca_landv_sp]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号轨道器太阳能电池板翼
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号轨道器的主太阳能电池板翼。\n\n面积：1.2 ㎡。
+}
+
+//Surveyor Landing Survey Camera
+@PART[ca_landv_cam_s1]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号着陆勘测相机
+    @manufacturer = 休斯飞机公司
+    @description = 这是勘测者号登陆器的主要勘测电视摄像机。内置的反射镜可以旋转 360 度，以拍摄着陆点的全景照片。
+}
+
+//Surveyor Soil Mechanics Surface Sampler
+@PART[ca_landv_soilScoop]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 勘测者号土壤表面机械采样器
+    @manufacturer = 休斯飞机公司
+    @description = 这是一种用于测试表层土壤物理特性（密度、孔隙率、电阻率）的仪器，并能暴露次表层土壤材料以供拍摄。
+}
+
+//CA-A02 Helical Omnidirectional Antenna
+@PART[antenna_cone_toggle]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-A02 螺旋全向天线
+    @description = 适用于月球范围通信的低增益全向天线。
+}
+
+//CA-GPS Omnidirectional Antenna
+@PART[ca_ant_gps]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-GPS 全向天线
+    @description = 此天线提供对全球定位系统（GPS）的访问，用于精确跟踪航天器的位置。虽然它可以作为全向天线使用，但在这一功能上效率较低。
+}
+
+//CA-A01 Ground Plane Antenna
+@PART[antenna_tv]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-A01 地面平面天线
+    @description = 这是一个用于遥测目的的简单全向天线。
+}
+
+@PART[antenna_tv]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球深空网络（DSN）的有效范围 [200 百万千米] — 功耗 [8 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [地球同步轨道]</color></b>
+}
+
+//CA-A06 Omnidirectional Antenna
+@PART[antenna_quetzal]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-A06 全向天线
+    @description = 这是一个简单的全向天线。可以用于短距离通信或作为中增益天线的备份。
+}
+
+@PART[antenna_quetzal]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description ^= :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [400 百万千米] — 功耗 [12 瓦特] — 最大数据速率 [512kb/s] — 使用场景 [地球同步轨道, 月球]</color></b>
+}
+
+//CA-A10 Folding Dish Antenna
+@PART[dish_deploy_S]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-A10 折叠式抛物面天线
+}
+
+@PART[dish_deploy_S]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [1.6 亿千米] — 功耗 [35 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [地球同步轨道, 月球]</color></b>
+}
+
+//Mariner Mars High Gain Antenna (HGA)
+@PART[dish_deploy_S2]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号火星高增益天线 (HGA)
+    @description = 用于早期水手号火星探测器系列的高增益抛物面天线。
+}
+
+@PART[dish_deploy_S2]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [350 亿千米] — 功耗 [20 瓦特] — 最大数据速率 [768 kbps] — 使用场景 [金星, 火星（不在冲日时）]</color></b>
+}
+
+//Juno Parabolic Antenna
+@PART[dish_hera]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 朱诺号抛物面天线
+    @description = 用于朱诺号探测器的高增益天线。
+}
+
+@PART[dish_hera]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [1 天文单位] — 功耗 [43 瓦特] — 最大数据速率 [2 Mbps] — 使用场景 [木星]</color></b>
+}
+
+//Voyager 1 & 2 Parabolic Antenna
+@PART[dish_L]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者 1 & 2 号抛物面天线
+    @manufacturer = 福特航空航天公司
+    @description = 用于旅行者 1 和 2 号探测器的高增益抛物面通信天线。
+}
+
+@PART[dish_L]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [37 天文单位] — 功耗 [93 瓦特] — 最大数据速率 [512 kbps] — 使用场景 [冥王星]</color></b>
+}
+
+//Pioneer 10 & 11 Parabolic Antenna
+@PART[dish_quetzal]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 先驱者 10 & 11 号抛物面天线
+    @description = 用于先驱者 10 和 11 号探测器的高增益抛物面通信天线。
+}
+
+@PART[dish_quetzal]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [1.7 天文单位] — 功耗 [57 瓦特] — 最大数据速率 [256 kbps] — 使用场景 [土星]</color></b>
+}
+
+//Ulysses Parabolic Antenna
+@PART[dish_S]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 尤利西斯号抛物面天线
+    @manufacturer = 阿斯特里姆
+    @description = 用于尤利西斯号探测器的抛物面通信天线。
+}
+
+@PART[dish_S]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [1 天文单位] — 功耗 [20 瓦特] — 最大数据速率 [2 Mbps] — 使用场景 [木星]</color></b>
+}
+
+//MAVEN Parabolic Antenna
+@PART[dish_tatsujin]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = MAVEN 抛物面天线
+    @description = MAVEN探测器的主要抛物面通信天线。
+}
+
+@PART[dish_tatsujin]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [400 亿千米] — 功耗 [30 瓦特] — 最大数据速率 [1 兆比特/秒] — 使用场景 [水星, 火星, 灶神星（不在冲日时）, 谷神星（不在冲日时）]</color></b>
+}
+
+//4MV Spacecraft Bus Antenna Array
+@PART[ca_vor_comm]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV 航天器平台天线阵列
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 辅助双全向圆锥天线阵列，用于短距离低增益通信。适用于轨道器与着陆器之间的通信链路。
+}
+
+@PART[ca_vor_comm]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [8 亿千米] — 功耗 [30 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [地球同步轨道, 月球]</color></b>
+}
+
+//4MV-1 Spacecraft Bus Parabolic Antenna
+@PART[ca_vor_dish]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV-1 航天器平台抛物面天线
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 4MV-1 航天器总线的主要高增益抛物面天线，通信范围能够覆盖内太阳系。
+}
+
+@PART[ca_vor_dish]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [350 亿千米] — 功耗 [30 瓦特] — 最大数据速率 [768 kbps] — 使用场景 [金星, 火星（不在冲日时）]</color></b> 
+}
+
+//Cassini Parabolic Antenna
+@PART[mer_dish]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号抛物面天线
+    @manufacturer = 意大利航天局
+    @description = 用于卡西尼号探测器的高增益抛物面通信天线，该天线集成了雷达高度计。
+}
+
+@PART[mer_dish]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [13.4 天文单位] — 功耗 [30 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [土星]</color></b>
+} 
+
+//STEREO Parabolic Antenna
+@PART[dish_xihe]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = STEREO 抛物面天线
+    @description = 用于STEREO（太阳-地球关系观测台）探测器的高增益抛物面通信天线。
+}
+
+@PART[dish_xihe]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [400 亿千米] — 功耗 [30 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [火星, 灶神星（不在冲日时）, 谷神星（不在冲日时）]</color></b>
+}
+
+//Mariner Mars & Venus High Gain Antenna (HGA)
+@PART[ca_argo-mk2-hga]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号火星与金星高增益天线 (HGA)
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 这是早期水手号火星和金星探测器系列的主要抛物面天线。包含低增益天线的安装点。
+}
+
+@PART[ca_argo-mk2-hga]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [351 亿千米] — 功耗 [20 瓦特] — 最大数据速率 [256 kbps] — 使用场景 [金星, 火星（不在冲日时）]</color></b>
+}
+
+//Mariner Mars & Venus Low Gain Antenna (LGA)
+@PART[ca_argo-mk2-mast]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号火星与金星低增益天线 (LGA)
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 早期水手火星和金星探测器系列的低增益天线。除了天线本身，它还包含一个磁强计和一个盖革计数器。
+}
+
+@PART[ca_argo-mk2-mast]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围 [200 百万千米] — 功耗 [10 瓦特] — 最大数据速率 [1 Mbps] — 使用场景 [地球轨道]</color></b>
+}
+
+
+//============
+//探测器核心部件
+//============
+
+
+// Juno Spacecraft Bus
+@PART[ca_hera]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 朱诺号探测器核心
+    @manufacturer = 洛克希德·马丁公司
+    @description = 这是朱诺号探测器的核心模块。包含先进的星敏感器、电池、反应控制系统（RCS）和推进剂储箱。宇航电子模块的重型结构保护其免受恶劣辐射带的影响。
+}
+
+//SSTL-150 Satellite Bus
+@PART[barquetta]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = SSTL-150 卫星平台
+    @manufacturer = 洛克希德·马丁公司
+    @description = 一个适用于小型卫星和探测器的通用平台模块。
+}
+
+//Voyager Core
+@PART[torekka]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者号探测器核心
+    @manufacturer = 喷气推进实验室(JPL)
+    @description = 用于旅行者号深空探测器的航空电子和控制单元。
+}
+
+//Pioneer 10/11 Core
+@PART[quetzal]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 先驱者 10/11 号探测器核心
+    @description = 用于先驱者 10/11 号探测器的航空电子和控制单元。
+}
+
+//LM-DS Generic Spacecraft Bus
+@PART[tatsujin]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = LM-DS 通用探测器平台
+    @manufacturer = 洛克希德·马丁公司
+    @description = 一个通用的航天器总线模块。典型应用包括火星勘测轨道器（MRO）、火星大气与挥发物演化任务（MAVEN）以及 OSIRIS-REx 任务。
+}
+
+//Venera Lander Bus
+@PART[ca_fom_lander]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号着陆器核心
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 金星9号 (4V-1) 至 金星14号 (4V-1M) 着陆器。这些着陆器是人类制造的第一个成功着陆并从其他行星体返回图像的物体。设计用于在极端温度和压力环境中承受剧烈着陆。
+}
+
+@PART[ca_fom_lander]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>有效范围：2 百万千米。功耗：30 瓦特。最大数据速率：256 kbps。使用场景：着陆器与轨道器之间的通信</color></b>
+}
+
+//4MV Spacecraft Bus
+@PART[ca_vor_core]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV 航天器核心
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 第四代 MV 标准航天器平台。提供改进的标准宇航电子设备、推进系统和通信系统，适用于广泛的无人任务。
+}
+
+//Huygens Atmospheric Lander
+@PART[ca_draco]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 惠更斯号大气探测器
+    @manufacturer = 欧洲航天局 (ESA)
+    @description = 惠更斯号是一个非常坚固、防水且具有浮力的探测器，设计用于大气层着陆。紧凑的舱室还包含电池、控制计算机、雷达高度计、着陆相机以及一套完整的紧凑型大气分析设备。
+}
+
+//Cassini Spacecraft Bus
+@PART[meridiani]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号探测器核心
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 卡西尼号探测器的航电模块。
+}
+
+//STEREO Spacecraft Bus
+@PART[xihe]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = STEREO 探测器核心
+    @manufacturer = 约翰斯·霍普金斯大学应用物理实验室
+    @description = STEREO（太阳-地球关系观测台）航天器核心模块。
+}
+
+//IUE Spacecraft Bus
+@PART[ca_explorer]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = IUE 探测器核心
+    @manufacturer = 美国国家航空航天局
+    @description = 这是国际紫外探测器（IUE）航天器的总线模块。包含电池、肼类燃料姿控系统（ACS）和短程通信系统。
+}
+
+@PART[ca_explorer]:NEEDS[RemoteTech&CoatlAerospace]:AFTER[RealismOverhaulRT]
+{
+    @description = :$: <b><color=#00eaf0>到地球 DSN 的有效范围：100 百万千米。功耗：6 瓦特。最大数据速率：256 kbps。使用场景：低地球轨道（LEO）、中地球轨道（MEO）、地球同步轨道（GEO）</color></b>
+}
+
+//Mariner Mars & Venus Spacecraft Bus
+@PART[ca_argo-mk2-mast]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号金星 & 火星探测器核心
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 用于水手号火星和金星任务的水手号航天器核心模块。
+}
+
+//===============================================================================
+//控制类部件
+//===============================================================================
+
+//RW-4A Radial Reaction Wheel Assembly
+@PART[ca_rw_large]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = RW-4A 径向动量轮组
+    @manufacturer = 蓝峡谷技术公司
+    @description = 这个动量轮组件结合了三个高性能的 RW4 动量轮，适用于需要精确姿态控制的大型航天器。
+}
+
+//RW-2A Radial Reaction Wheel Assembly
+@PART[ca_rw_medium]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = RW-2A 径向动量轮组
+    @manufacturer = 蓝峡谷技术公司
+    @description = 这个动量轮组件结合了两个高性能的 RW4 动量轮，适用于需要精确姿态控制的中型航天器。
+}
+
+//RW4 Radial Reaction Wheel
+@PART[ca_rw_small]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = RW4 径向动量轮
+    @manufacturer = 蓝峡谷技术公司
+    @description = 这些是高性能的动量轮，用于航天器的精确姿态控制。
+}
+
+//RW1 Radial Reaction Wheel
+@PART[ca_rw_xsmall]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = RW1 径向动量轮
+    @manufacturer = 蓝峡谷技术公司
+    @description = 用于航天器精确姿态控制的高性能反作用轮。
+}
+
+//CA-AACS Advanced Attitude Control System
+@PART[ca_aacs]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-AACS 高级姿态控制系统
+    @description = 这是一个集成计算机系统，利用两个星敏感器和环形激光陀螺仪（RLG），为航天器提供姿态控制信息。
+}
+
+//CA-ACS 'StarTrack' Attitude Control System
+@PART[ca_startrack]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-ACS "星轨" 姿态控制系统
+    @description = 这是一个高灵敏度的星敏感器。通过测量不同恒星之间的角度，并与存储的数据库数据进行比较，它为航天器提供姿态控制信息。
+}
+
+//CAE-RM01 RCS Thruster Block
+@PART[ca_rm01]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CAE-RM01 RCS推进器
+    @description = 这是一个用于上面级或中型航天器姿态控制的 RCS 推进器模块。
+}
+
+//CAE-RM02 RCS Thruster Block
+@PART[ca_RM02]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CAE-RM02 RCS推进器
+    @description = 这是一个用于上面级或中型航天器姿态控制的 RCS 推进器模块。它提供了精确的姿态调整能力，确保航天器在轨道操作和姿态稳定时的高精度控制。该模块包含四个推力矢量喷嘴，能够实现全方位的姿态调整。
+}
+
+//CAE-RM03 RCS Thruster Block
+@PART[ca_RM03]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CAE-RM03 RCS推进器
+    @description = 这是一个用于上面级或中型航天器姿态控制的 RCS 推进器模块。它提供了精确的姿态调整能力，确保航天器在轨道操作和姿态稳定时的高精度控制。
+}
+
+//CAE-RM04 RCS Thruster Block
+@PART[ca_RM04]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CAE-RM04 RCS推进器
+    @description = 这是一个用于上面级或中型航天器姿态控制的 RCS 推进器模块。它提供了精确的姿态调整能力，确保航天器在轨道操作和姿态稳定时的高精度控制。该模块包含四个推力矢量喷嘴，能够实现全方位的姿态调整。
+}
+
+//CA-RS01 RCS Thruster Block
+@PART[ca_RS01]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-RS01 RCS推进器
+    @description = 这是一个非常紧凑的小型 RCS 系统，提供方向推力。该系统设计精巧，适用于需要精确姿态控制的小型航天器或子系统。它能够在有限的空间内提供高效的推力矢量控制，确保航天器在轨道调整和姿态稳定时的高精度操作。适用于小型卫星、探测器以及需要精细姿态控制的任务。
+}
+
+//CA-RS04 RCS Thruster Block
+@PART[ca_RS04]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-RS04 RCS推进器
+    @description = 这个四喷嘴 RCS 推进器模块专为小型航天器的姿态控制系统设计，能够有效补充姿态控制系统的功能。该模块包含四个推力矢量喷嘴，能够在有限的空间内提供全方位的姿态调整能力。
+}
+
+//CA-RST RCS Thruster Block
+@PART[ca_RST]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-RST RCS推进器
+    @description = 这个紧凑型推进器模块可以使用单个喷嘴作为方向 RCS 推进器，也可以同时使用全部三个喷嘴作为可调推力火箭发动机。该模块设计灵活，适用于多种任务需求，如精确姿态控制和轨道调整。
+}
+
+//Cassini Lower Equipment Unit
+@PART[ca_mer_leu]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号下部设备单元
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 这是卡西尼号探测器的下部设备单元。包含推进系统、姿态控制系统和其他关键设备。该模块设计用于支持长时间深空任务。
+}
+
+
+
+
+//==============================================================================
+//分离器部件
+//==============================================================================
+
+//Huygens Aeroshell
+@PART[ca_draco_as]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 惠更斯号防护外壳
+    @manufacturer = 欧洲航天局 (ESA)
+    @description = 一个用于保护惠更斯号大气探测器的防护外壳。
+}  
+
+//Huygens Structural Adapter
+@PART[mer_ringDecoupler]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼-惠更斯号安装适配器
+    @description = 这是一个独立的卡西尼-惠更斯号适配器安装组件，可用于其他航天器平台。通过爆炸螺栓释放着陆器有效载荷。
+}
+
+//Venera Reentry Module Decoupler
+@PARTp[ca_vor_sep1]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号大气着陆器分离环
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这个适配器用于连接4MV航天器平台和金星号着陆器的分离器。注意：在再入大气层前必须释放！
+}
+
+
+//==============================================================================
+//电力部件
+//==============================================================================
+
+//CA-300i Battery
+@PART[ca_battery_l]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-300i 电池
+    @description = 这是一款可充电的银氧化物电池，适用于长时间任务的航天器。容量为 <color=orange>1500 Wh</color>，具有高效能和可靠性，能够在极端环境下稳定工作。
+}
+
+//CA-100i Battery
+@PART[ca_battery_100i]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-100i 电池
+    @description = 这是一款可充电的银氧化物电池，适用于中小型航天器和卫星。容量为 <color=orange>800 Wh</color>，具有高效能和可靠性，能够在极端环境下稳定工作。
+}
+
+//CA-25i Battery
+@PART[ca_battery_s]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-25i 电池
+    @description = 这是一款可充电的银氧化物电池，低矮的设计便于安装。容量为 <color=orange>440 Wh</color>
+}
+
+//Pioneer SNAP-19 RTG
+@PART[ca_rtg2000]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 先驱者号 SNAP-19 放射性同位素热电发电机
+    @manufacturer = 泰莱达科技公司
+    @description = 这是先驱者号航天器上使用的SNAP-19放射性同位素热电发电机。由美国原子能委员会（AEC）开发。它利用放射性衰变产生的热量转化为电能，为长期深空任务提供稳定的电力支持。
+    @MODULE[ModuleAnimationGeneric]
+    {
+        @startEventGUIName = 伸展 RTG 吊杆
+        @endEventGUIName = 收缩 RTG 吊杆
+        @actionGUIName = 开关 RTG 吊杆
+    }
+}
+
+//Voyager MHW-RTG
+@PART[ca_rtg3900]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者号 MHW-RTG
+    @description = 这是旅行者号航天器上使用的数百瓦级钚-238放射性同位素热电发电机（MHW-RTG）。它利用放射性衰变产生的热量转化为电能，为长时间深空任务提供稳定的电力支持。这种发电机能够确保在极端环境下持续供电，适用于深空探测任务。
+    @MODULE[ModuelAnimationGeneric]
+    {
+        @startEventGUIName = 伸展 RTG 吊杆
+        @endEventGUIName = 收缩 RTG 吊杆
+        @actionGUIName = 开关 RTG 吊杆
+    }
+}
+
+//GPHS-RTG
+@PART[ca_rtg8200|ca_mer_rtg]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 通用热源放射性同位素热电发电机
+    @manufacturer = 美国能源部
+    @description = 这是通用热源放射性同位素热电发电机（GPHS-RTG），安装在卡西尼号、尤利西斯号和新视野号航天器上。它利用放射性衰变产生的热量转化为电能，为长时间深空任务提供稳定的电力支持。这种发电机能够在极端环境下持续供电，适用于深空探测任务。
+}
+
+//Venus Express Solar Array Wing (SAW)
+@PART[sp_express_a]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星快车号太阳能板
+    @description = 这是金星快车号航天器使用的太阳能阵列翼。面积为 <color=orange>2.85 m²</color>。该阵列翼为航天器提供必要的电力支持，确保其在金星轨道上的各种科学仪器能够正常运行。
+}
+
+//Mars Express Solar Array Wing (SAW)
+@PART[sp_express_b]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 火星快车号太阳能板
+    @description = 这是火星快车号航天器使用的太阳能阵列翼。面积为 <color=orange>5.75 m²</color>。
+}
+
+//Juno Solar Array Wing (Standard)
+@PART[sp_juno]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 朱诺号太阳能电池板 (标准版)
+    @manufacturer = 洛克希德·马丁公司
+    @description = 这是朱诺号探测器的标准版太阳能阵列翼。面积为 <color=orange>24 m²</color>。
+}
+
+//Juno Solar Array Wing (Magnetometer)
+@PART[sp_juno_mag]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 朱诺号太阳能电池板 (磁强计版)
+    @manufacturer = 洛克希德·马丁公司
+    @description = 这是朱诺号探测器的磁强计版太阳能阵列翼。面积 <color=orange>24 m²</color>。\n\n该版本适用于需要测量磁场的任务。
+    
+}
+
+//sp_mariner_a
+@PART[sp_mariner_a]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @description = 这是一个类似于水手号火星探测器使用的太阳能阵列翼。面积为 <color=orange>2.34 m²</color>。
+}
+
+//sp_mariner_b
+@PART[sp_mariner_b]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @description = 这是一个类似于水手号火星探测器使用的太阳能阵列翼，面积为 <color=orange>2.34 m²</color>。
+}
+
+//MAVEN Solar Array Wing (SAW)
+@PART[sp_maven]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = MAVEN 太阳能电池板
+    @description = 这是用于火星大气与挥发物演化任务（MAVEN）航天器的太阳能阵列翼，面积为 <color=orange>11.5 m²</color>。该阵列翼包括一个三轴磁强计，用于测量磁场数据，同时为航天器提供必要的电力支持。
+}
+
+//Mars Odyssey Solar Array Wing (SAW)
+@PART[sp_odyssey_a]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 火星奥德赛号电池板
+    @description = 这是火星奥德赛号航天器使用的非常高效的砷化镓（GaAs）光伏板。面积为 <color=orange>5.88 m²</color>。该光伏板采用偏心旋转点设计，最小化其收纳时的占地面积，从而提高空间利用率。
+}
+
+//sp_odyssey_b
+@PART[sp_odyssey_b]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @description = 这是一个基于E200系列的改进型光伏系统，面积为 <color=orange>5.46 m²</color>。
+}
+
+//Venera Lander Bus Solar Array
+@PART[ca_fom_sp]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号着陆器太阳能电池板
+    @description = 这是一个小型且基础的太阳能板，面积为 <color=orange>0.15 m²</color>。
+}
+
+//4MV Spacecraft Bus SAW & TCS (Standard)
+@PART[sp_vor_sp]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV探测器太阳能电池板 (标准版)
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这是4MV航天器平台的主要太阳能阵列翼和热控制系统（TCS）。该配置适用于金星任务，采用较小的阵列和一个大型主动散热器以支持冷却系统。散热能力为 <color=orange>2 kWh</color>，太阳能阵列面积为 <color=orange>5.25 m²</color>。
+}
+
+//4MV Spacecraft Bus SAW & TCS (Small)
+@PART[ca_vor_sp2]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV探测器太阳能电池板 (低配版)
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这是4MV航天器平台的另一种太阳能阵列和热控制系统（TCS）装配。该配置仅包含两个太阳能阵列翼，但保留了相同的散热器组件。散热能力为 <color=orange>2 kWh</color>，太阳能阵列总面积为 <color=orange>2.7 m²</color>。
+}
+
+//STEREO Solar Array Wing (SAW)
+@PART[sp_stereo]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = STEREO 太阳能电池板
+    @description = 这是STEREO（太阳地球关系观测台）航天器使用的太阳能电池板。面积为 <color=orange>1.85 m²</color>。
+}
+
+//IUE Solar Array Wing (SAW)
+@PART[ca_explorer_solar]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = IUE 太阳能电池板
+    @description = 这是为国际紫外探测器（IUE）航天器设计的太阳能电池板。面积为 <color=orange>2 m²</color>。该电池板采用3合1设计，并增加了面板接收太阳光的角度范围，从而只需要粗略对准太阳即可有效工作。
+}
+
+//Mariner Mars Solar Array Wing (SAW)
+@PART[ca_argo-mk2-solar]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号火星探测器太阳能电池板
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 这是为水手号火星探测器设计的太阳能电池板。面积为 <color=orange>1.58 m²</color>。特点包括：集成的冷气姿态控制系统，用于主动姿态控制。包含太阳风挡板，提供被动稳定性弹簧加载的展开机制，一旦展开后面板无法被收回。
+}
+
+//==============================================================================
+//引擎&燃料箱部件
+//==============================================================================
+
+
+//Cassini Main Engine Assembly
+@PART[mer_engine]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号主引擎组
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 这是卡西尼号轨道器的主要发动机组件。包含两台R-4D-11双组元燃料发动机。通过一个俯仰平台提供推力矢量控制功能。
+}
+
+//Cassini Propulsion Module
+@PART[ca_mer_ft]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号推进模块
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 这是卡西尼号航天器的主要推进模块。它包含推进剂储箱、姿态控制系统（ACS）推进器以及备用的可动动量组件（ARWA）。可以通过右键菜单切换热防护罩。
+}
+
+//Generic 0.5 kN Thruster
+@PART[ca_jib]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 通用0.5 kN推进器
+    @description = 这是一款通用的单组元/双组元火箭发动机。可以在广泛的推进剂类型中进行配置。通过喷嘴挡板实现推力矢量控制。
+}
+
+//CA-LT80 Propellant Tank (Pressurized)
+@PART[ca_tank_lfo_m]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-LT80 推进剂储箱（加压型）
+    @description = 这是一款适用于中型航天器的通用高压推进剂储箱。它可以在高压环境下储存和供应推进剂，确保长时间任务中的稳定性能。
+}
+
+//CA-MT170 Propellant Tank (Pressurized)
+@PART[ca_tank_mp_m]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-MT170 推进剂储箱（加压型）
+    @description = 这是一款通用的高压推进剂储箱，适用于中型航天器。它可以在高压环境下储存和供应推进剂，确保长时间任务中的稳定性能。
+}
+
+//CA-MT10 Propellant Tank (Pressurized)
+@PART[ca_tank_mp_s]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-MT10 推进剂储箱（加压型）
+    @description = 这是一款通用的高压推进剂储箱，适用于小型航天器。它可以在高压环境下储存和供应推进剂，确保长时间任务中的稳定性能。该储箱设计为径向安装，以适应不同的航天器结构需求。
+}
+
+//Bi-Propellant Apogee Engine
+@PART[ca_trident]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 双组元远地点发动机
+    @manufacturer = 赛峰集团
+    @description = 该组件包含三个400N双组元远地点发动机。设计用于地球静止卫星的远地点轨道切入以及深空探测器的轨迹和行星轨道机动。
+}
+
+//Voyager Propulsion Module
+@PART[ca_torekkaPM]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者号推进模块
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 旅行者号推进模块由改进版的STAR-37E固体火箭发动机提供动力。它包含一个反应控制系统（RCS），用于在整个固推燃烧期间控制旅行者号的姿态。请将其安装在旅行者号桁架适配器的底部。
+}
+
+//CAE-MT12 Propellant Tank (Pressurized)
+@PART[ca_vor_mptank]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CAE-MT12 推进剂储箱（加压型）
+    @description = 这是一款通用的高压推进剂储箱，设计为径向安装。适用于需要在高压环境下储存和供应推进剂的任务，确保长时间任务中的稳定性能。
+}
+
+//4MV-1/2 Spacecraft Bus Propellant Tank
+@PART[ca_vor_tank]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 4MV-1/2 航天器平台推进剂储箱
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这是4MV-1/2航天器平台的主要加压推进剂储存模块。该储箱设计用于在高压环境下安全地储存和供应推进剂，确保航天器在长时间任务中的稳定性能。
+}
+
+//==============================================================================
+//科学仪器
+//==============================================================================
+
+//Cassini Dual Technique Magnetometer
+@PART[mer_mag]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号双技术磁强计
+    @manufacturer = 喷气推进实验室 (JPL) & 伦敦帝国理工学院 (ICL)
+    @description = 这款先进的磁强计单元使用两种不同的磁强计仪器（标量氦磁强计和磁通门磁强计）来收集并交叉验证测量数据，消除航天器干扰并提高测量精度。
+}
+
+//Cassini Optical Remote Sensing Package
+@PART[mer_rsp]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号光学遥感组件
+    @description = 卡西尼号的光学遥感组件，也称为遥感托盘，是一组由相机和光谱仪组成的仪器，设计用于捕捉从红外到紫外多个波长范围内的图像和光谱图。该组件包括：复合红外光谱仪（CIRS）、成像科学子系统（ISS）、紫外成像光谱仪（UVIS）以及可见光和红外测绘光谱仪（VIMS）。
+}
+
+//ASCAT
+@PART[ca_H2RS]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 高级散射计
+    @manufacturer = 空客防务与航天公司
+    @description = 高级散射计（ASCAT）是一种真实孔径合成雷达。它向天体表面发射长无线电脉冲，并测量回波被接收器检测到所需的时间。较简单的版本最初用于欧洲的ERS-1和ERS-2以及Envisat地球气象卫星，而改进设计现在则应用于MetOp卫星系列。
+}
+
+//Mars Orbiter Laser Altimeter (MOLA)
+@PART[ca_HOLA]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 火星轨道器激光测高仪 (MOLA)
+    @manufacturer = 麦克唐纳·道格拉斯公司
+    @description = MOLA 是火星全球探勘者号航天器上的四种仪器之一。它重复发射短持续时间的红外激光脉冲到天体表面，并测量脉冲反射并被望远镜记录所需的时间。通过这种方式，MOLA 可以构建精度非常高的地形图。
+}
+
+//CA-TRIXIE Multi-spectral Imager
+@PART[ca_TRIXIE]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-TRIXIE 多光谱成像仪
+    @description = TRIXIE 仪器集成了两个相机组件、一个紫外光谱仪和一个多光谱相机，以对从紫外线到近红外线的多个波长进行成像和扫描。这为从轨道上确定表面特性和特征提供了一种有效的方法。
+}
+
+//CA-SC103 Accelerometer
+@PART[ca_accelerometer]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SC103 加速度计
+    @description = SC103 配备了灵敏的传感器，可以检测到地震振动和航天器加速度。这对于监测航天器的运动状态以及研究天体表面的地震活动非常有用。
+}
+
+//CA-SC102 Barometer
+@PART[ca_barometer]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SC102 气压计
+    @description = SC102 用于测量局部大气压力。这对于了解着陆点或飞行路径上的天气条件以及大气密度变化至关重要。
+}
+
+//CA-DUST-C Dust Sample Collector
+@PART[ca_DUSTC]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-DUST-C 尘埃样本收集器
+    @description = DUST-C 模块配备有气凝胶涂层的收集装置，用于捕捉尘埃颗粒并将其带回地球进行分析。注意：此模块不包含热防护罩和降落伞。
+}
+
+//CA-DUST-X Cosmic Dust Counter
+@PART[ca_DUSTX]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-DUST-X 宇宙尘埃计数器
+    @description = DUST-X 是一种用于收集尘埃颗粒并提供其大小、速度和方向信息的仪器。这对于研究宇宙尘埃的来源和特性以及了解太空环境中的微粒分布非常重要。
+}
+
+//CA-ELIX Electrostatic & Ionization Experiment
+@PART[ca_ELIX]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-ELIX 静电与电离实验仪
+    @description = ELIX 是一种静电分析仪，用于分析带电粒子的组成。通过使用电场和磁场，ELIX 可以根据粒子的质量和电荷对其进行浓缩和分离，从而实现对等离子体密度、速度和分布的非常精确的测量。
+}
+
+//CA-SC104 Gravity Gradiometer
+@PART[ca_gravioli]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SC104 重力梯度仪
+    @description = SC104 重力梯度仪用于测量行星体的重力加速度。通过测量重力梯度，可以进行若干关于地下结构和形态的间接观测。这对于研究天体内部构造和地质特征非常重要。
+}
+
+//CA-SCGRS Gamma Ray Spectrometer
+@PART[ca_GRS]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SCGRS 伽马射线光谱仪
+    @description = 伽马射线光谱仪用于测量当行星表面受到宇宙射线轰击时产生的伽马射线能量。通过测量伽马射线能量，我们可以确定土壤中的元素组成及其浓度。这对于研究天体表面的物质成分和地质历史非常重要。
+}
+
+//CA-THEMIS Infrared Spectrometer
+@PART[ca_KLIR]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-THEMIS 红外光谱仪
+    @description = THEMIS（热辐射成像系统）用于测量行星体的热辐射，计算表面温度或绘制表面特征的小细节地图。该光谱仪还可以测量红外发射的波长，以检测土壤中的特定矿物成分。这对于研究天体表面的热性质和地质组成非常重要。
+}
+
+//CA-IUVS Imaging Ultraviolet Spectrometer
+@PART[ca_LUV]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-IUVS 成像紫外光谱仪
+    @description = IUVS（成像紫外光谱仪）用于成像紫外线谱段的较低部分。通过这种方式，它可以测量高层大气和电离层的整体特性，提供关于太阳风与大气之间相互作用的信息，以及这些层的组成和形态。这对于研究天体的大气结构和动态过程非常重要。
+}
+
+//Cassini Radio and Plasma Wave Science
+@PART[ca_RPWS]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 卡西尼号无线电和等离子体波科学仪器
+    @description = 无线电和等离子体波科学（RPWS）仪器使用灵敏的宽带电场和磁场传感器，以及离子阱探针来测量行星际介质和行星磁层中的电场、磁场、电子密度和温度。这对于研究太阳风与磁层的相互作用、等离子体波以及天体周围的电磁环境非常重要。
+}
+
+//STEREO/WAVES
+@PART[ca_RPWS_STEREO]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = STEREO/WAVES
+    @manufacturer = 巴黎天文台
+    @description = STEREO/WAVES（SWAVES）是一个行星际无线电爆发追踪器，用于追踪从太阳到地球轨道的行进无线电扰动的产生和演化。该仪器对于研究太阳活动对地球和行星际空间环境的影响至关重要。
+}
+
+//Voyager Science Boom
+@PART[ca_sciBoom]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者号科学仪器伸杆
+    @description = 这是旅行者号深空探测器的科学伸杆。伸杆上安装有窄角和广角相机，用于轨道勘测成像，同时还配备了红外和紫外光谱仪。注意：部署伸杆以使实验设备远离电子设备产生的电磁干扰和辐射。
+}
+
+//STEREO Boom Suite
+@PART[ca_stereoBoom]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = STEREO 伸杆组件
+    @manufacturer = 加州大学洛杉矶分校 (UCLA)
+    @description = STEREO 科学伸杆携带了一个非常紧凑的三轴磁强计和一个太阳风实验装置，能够提供太阳高能粒子的等离子体特性以及局部矢量磁场。这对于研究太阳活动及其对行星际空间环境的影响非常重要。
+}
+
+//CA-SWIA Solar Wind Analyzer
+@PART[ca_SWIS]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SWIA 太阳风分析仪
+    @description = 太阳风分析仪（SWIA）专门设计用于检测和测量太阳风中的电子和离子的速度及密度。这对于研究太阳风特性及其对地球和行星际空间环境的影响至关重要。
+}
+
+//CA-HiRISE Telescope
+@PART[ca_telescope_a]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-HiRISE 望远镜
+    @description = 高分辨率成像科学实验（HiRISE）是一台卡塞格林型可见光谱望远镜，也是飞越深空的探测器中最大的望远镜之一。凭借其高分辨率能力，它可以获取高清晰度的彩色表面图像。这对于研究天体表面特征和地质结构非常重要。
+}
+
+//CA-SC100 Infrared Radiometer
+@PART[ca_thermometer]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-SC100 红外辐射计
+    @description = SC100 红外辐射计用于测量红外辐射通量，提供关于大气和/或表面土壤温度的信息。这对于研究天体的热特性以及环境条件非常重要。
+}
+
+//Triaxial Helium Vector Magnetometer
+@PART[ca_magneto2]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 三轴氦矢量磁强计
+    @description = 磁强计仪器用于确定行星磁场的强度和方向。长伸杆将这些仪器与探测器中的磁性元件造成的任何干扰隔离开来，确保测量的准确性。
+}
+
+//Vega Camera & Spectrometer Platform
+@PART[ca_vor_camera]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 织女星相机与光谱仪平台
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = VCS 组件安装了一整套轨道成像设备，包括电视系统（TVS）、覆盖从红外到紫外光谱的三通道光谱仪（TKS），以及用于分析尘埃颗粒质量和化学组成的尘埃质谱仪（PUMA）。该平台具有灵活的安装系统，支持直装和角度安装选项。
+}
+
+//Venera Magnetometer
+@PART[ca_vor_mag]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号磁强计
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 磁强计仪器用于确定行星磁场的强度和方向。长伸杆将这些仪器与探测器中的磁性元件造成的任何干扰隔离开来，确保测量的准确性。
+}
+
+//Venera Synthetic Aperture Radar Assembly
+@PART[ca_vor_sar]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号合成孔径雷达组件
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这是金星15号和16号航天器的合成孔径雷达组件。该表面测绘雷达能够创建高分辨率的金星地形图，揭示关于金星地质形态的丰富信息。
+}
+
+//Mariner Mars Scan Platform
+@PART[ca_argo-mk2-cam]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 水手号火星扫描平台
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 水手号火星扫描平台集成了两台电视摄像机、一台红外辐射计、一台红外光谱仪和两个星敏感器。该组件具有两自由度的机制，可以根据每次任务的相遇参数使仪器套件移动。
+}
+
+//=================================================================================
+//结构部件
+//=================================================================================
+
+//Voyager Truss Adapter
+@PART[ca_torekka_truss]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 旅行者号桁架适配器
+    @manufacturer = 喷气推进实验室 (JPL)
+    @description = 该桁架安装在旅行者号平台的底部，用于安全且稳固地连接其固体火箭发动机（SRM）推进模块。
+}
+
+//=================================================================================
+//热量部件
+//=================================================================================
+
+//Huygens Heat Shield
+@PART[ca_draco_hs]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 惠更斯号热防护盾
+    @manufacturer = 欧洲航天局 (ESA)
+    @description = AQ60 瓷砖覆盖了这个设计用于保护惠更斯号大气着陆器在进入大气层时的热防护盾组件。通过气动外形设计和烧蚀材料的应用，该热防护盾能够将因大气压缩产生的热量转移远离着陆器。
+}
+
+//Venera Lander Aeroshell (Heat Shield)
+@PART[ca_fom_heatS]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号着陆器外壳（热防护盾）
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这是金星号外壳的底部组件。它涂有烧蚀材料，以防止着陆器在再入大气层时因巨大的热量负荷而被摧毁。
+}
+
+//CA-TCL4 Thermal Control Louver
+@PART[ca_louver_s]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-TCL4 百叶窗热控系统
+    @description = 百叶窗热控系统是热控制系统，通过暴露冷却翅片和散热器来排出热量。打开通风口可以释放航天器内部的热量。这是标准尺寸的系统，额定散热能力为 40 瓦。
+}
+
+//CA-TCL4-B Thermal Control Louver
+@PART[ca_louver_s2]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-TCL4-B 百叶窗热控系统
+    @manufacturer = 通用制造商
+    @description = 百叶窗热控系统是热控制系统，通过暴露冷却翅片和散热器来排出热量。打开通风口可以释放航天器内部的热量。这是TCL4的另一种更长版本，额定散热能力为50瓦。
+}
+
+//CA-TCL8 Thermal Control Louver
+@PART[ca_louver_m]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = CA-TCL8 百叶窗热控系统
+    @description = 百叶窗热控系统是热控制系统，通过暴露冷却翅片和散热器来排出热量。打开通风口可以释放航天器内部的热量。该系统高度和性能是TCL4-B的两倍，提供更佳的冷却效果。额定散热能力为100瓦。
+}
+
+//=================================================================================
+//其他部件
+//=================================================================================
+
+//Huygens Drogue Parachute
+@PART[ca_draco_drogue]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 惠更斯号阻力伞
+    @manufacturer = 马丁-贝克空间系统公司 (Martin-Baker Space Systems)
+    @description = 这款尼龙-凯夫拉材质的阻力伞用于稳定惠更斯号探测器的最终下降阶段。其盘-缝-带（Disk-Gap-Band）几何结构允许在低动态压力下充气，并具有出色的稳定性。
+}
+
+//Huygens Main Parachute
+@PART[ca_draco_parachute]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 惠更斯号主降落伞
+    @manufacturer = 马丁-贝克空间系统公司 (Martin-Baker Space Systems)
+    @description = 这款尼龙-凯夫拉材质的主降落伞在热防护盾分离后部署，用于将下降速度减至亚音速，以便后续展开稳定阻力伞。其盘-缝-带（Disk-Gap-Band）几何结构允许在低动态压力下充气，并提供出色的稳定性。
+}
+
+//Pioneer 10/11 Science Package
+@PART[ca_ESM]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 先驱者 10/11 号科学仪器包
+    @description = 这是一个最初为先驱者 10 号和 11 号深空探测器设计的集成科学仪器包。包含一个热控制系统，具备50瓦的散热能力。
+}
+
+//LM900 Satellite Bus
+@PART[ca_ESM2]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = LM900 卫星平台
+    @manufacturer = 洛克希德·马丁空间系统公司 (Lockheed Martin Space Systems)
+    @description = 这是一个轻量级的三轴稳定的卫星平台，能够携带多种有效载荷。该平台设计灵活，适用于各种航天任务，包括地球观测、通信和科学实验。
+}
+
+//Venera Lander Aeroshell (Drogue Parachute)
+@PART[ca_fom_drogue]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号着陆器气动外壳（阻力伞）
+    @manufacturer = 拉沃契金科研生产联合体 (NPO Lavochkin)
+    @description = 这是金星号大气进入舱的顶部盖子。阻力伞包直接连接到金星号着陆器，在再入大气层后和气动外壳分离前部署。较小的有效伞面积允许更快但更为剧烈的着陆。
+}
+
+//Venera Lander Aeroshell (Main Parachute)
+@PART[ca_fom_parachute]:NEEDS[RealismOverhaul&CoatlAerospace]:FINAL
+{
+    @title = 金星号着陆器外壳（主降落伞）
+    @manufacturer = 拉沃契金科研生产联合体
+    @description = 这个部件是金星大气进入舱的顶部盖板。降落伞组件直接连接到金星着陆器，在再入大气层后和外壳分离前进行部署。较大的有效降落伞面积允许更缓慢但更柔和的着陆。
+}
+
+
+
+

--- a/GameData/0000Tinygrox_CNPatches/Coatl Aerospace/ProbePlus-Stock-Patches.cfg
+++ b/GameData/0000Tinygrox_CNPatches/Coatl Aerospace/ProbePlus-Stock-Patches.cfg
@@ -1,0 +1,2688 @@
+//Agency
+// @AGENT[Coatl Aerospace]
+// {
+//     @description = Coatl Aerospace 最初是一家电子电路制造商。在创始人兼首席执行官 Leo Kerman 的领导下，公司开始制造自己的探测器核心，并从此扩展到航空航天领域的许多方面，开创了自主太空探索的新纪元。
+// }
+
+//============
+//金属箔颜色切换
+//============
+@PART[*]:HAS[@MODULE[FSmeshSwitch]]:AFTER[CoatlAerospace]
+{
+    @MODULE[FSMeshSwitch]
+    {
+        @buttonName = 切换下一个颜色
+        @previousButtonName = 切换上一个颜色
+        @objectDisplayNames = 无覆盖;金属箔覆盖
+    }
+    @MODULE[FStextureSwitch2]
+    {
+        @textureDisplayNames = 金色;金箔;导热层;银箔;Coatl外套箔
+    }
+}
+
+//================
+//------部件------
+//================
+
+//=========
+//勘测者系列
+//=========
+//CA-55i Landvermesser Battery
+@PART[ca_landv_battery]:AFTER[CoatlAerospace]
+{
+    @title = CA-55i 勘测者电池
+    @description =  这个电池最初是为一个科学实验设计的容器。然而，由于蓝图中缺少关键页面，为了防止设计延误，工程师们决定直接塞入一个高密度电池。尽管如此，这款电池依然具备出色的能量密度和可靠性，适用于各种探测任务。
+}
+
+//CA-CAM-S1 Landing Site Survey Camera
+@PART[ca_landv_cam_s1]:AFTER[CoatlAerospace]
+{
+    @title = CA-CAM-S1 勘测者相机
+    @description = 带有旋转镜窗的相机通过反射镜窗口可以拍摄着陆点的全景拼接图像，而无需移动相机主体。这种设计使得在派遣宇航员之前，能够高效地评估着陆点的安全性和地形特征。相机配备了一次性的胶片盒，只能进行一次完整的着陆点调查。如果任务需要多次调查，建议携带备用相机或由宇航员在地面操作更换胶片。此外，该相机还具备高分辨率成像能力，能够提供详细的地形数据，有助于后续的任务规划和安全评估。
+    @MODULE
+    {
+        @endEventGUIName = 执行现场勘测
+        @startEventGUIName = 启动
+        @toggleEventGUIName = 切换动作
+        @collectActionName = 收集数据
+        @experimentActionName = 拍摄着陆点图像
+        @resetActionName = 重置数据
+        @reviewActionName = 查看数据
+        @transmitWarningText = 无法传输数据
+        @customFailMessage = 无法进行现场勘测！仅在着陆时进行
+        @deployingMessage = 正在拍摄着陆点图像...
+        @planetFailMessage = 无法在此处进行勘测
+    }
+}
+
+//CA-L100 'Landvermesser' Lander
+@PART[ca_landv_core]:AFTER[CoatlAerospace]
+{
+    @title = CA-L100 "勘测者"着陆器
+    @description =  这款非常轻便且坚固的探测器设计用于在载人飞行前执行着陆点勘测任务。它配备了一组着陆腿和3个 vernier 发动机所需的推进剂（需单独购买）。此外，为了正常执行离轨机动，还需要配备固体燃料反推发动机。
+    @MODULE[MuduleAnimateGeneric]
+    {
+        @startEventGUIName = 展开着陆装置
+        @endEventGUIName = 收起着陆装置
+        @actionGUIName = 开关着陆装置
+    }
+}
+
+//CA-AE20 HGA Antenna and Solar Panel
+@PART[ca_landv_hga]:AFTER[CoatlAerospace]
+{
+    @title = CA-AE20 高增益天线及太阳能板
+    @description =  这个高增益天线和太阳能板将用于在着陆时收集数据。它将位于探测仪桅杆上，并使用一个单独的太阳能板来充电电池。
+}
+
+//CA-A07 Landvermesser Omni Antenna
+@PART[ca_landv_omni]:AFTER[CoatlAerospace]
+{
+    @title = CA-A07 勘测者全向天线
+    @description =  这个全向天线将用于在着陆时收集数据。它将安装在探测仪桅杆上。
+}
+
+//CA-100B 'Landvermesser' B Core
+@PART[ca_landv_orbiter_core]:AFTER[CoatlAerospace]
+{
+    @title = CA-100B 改进型"勘测者"核心
+    @description =  为了便于制造和零件兼容性，我们基于勘探者着陆器平台开发了一种改进的卫星平台，用于轨道操作。通过移除着陆设备节省的质量被用于增加3个vernier发动机（需单独购买）的推进剂罐容量，这大大扩展了其航程和轨道修正能力。此外，还提供了专为太空操作设计的新天线和太阳能电池板。
+}
+
+//CA-A20-B HGA Antenna
+@PART[ca_landv_orbiter_hga]:AFTER[CoatlAerospace]
+{
+    @title = CA-A20-B 改进型"勘测者"高增益天线
+    @description =  这个高增益天线将用于在着陆时收集数据。它将安装在探测仪桅杆上。
+}
+
+//CA-SC28-L Topsoil Scoop
+@PART[ca_landv_soilScoop]:AFTER[CoatlAerospace]
+{
+    @title = CA-SC28-L 表面土壤采样铲
+    @description = 这个采样铲专为采集行星表面的土壤样本而设计。它能够有效地收集表层土壤，以便进行科学分析。该工具在行星勘测任务中非常重要，可以帮助科学家了解目标天体的地表成分和特性。
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @endEventGUIName = 采集表面土壤
+        @startEventGUIName = 采集表面土壤
+        @toggleEventGUIName = 切换动作
+        @collectActionName = EVA 数据收集
+        @experimentActionName = 采集表面土壤
+        @resetActionName = 重置数据
+        @reviewActionName = 查看数据
+        @transmissionWarningText = 无法传输数据
+        @customFailMessage = 无法采集表面土壤！仅在着陆时进行
+        @deployingMessage = 正在采集表面土壤...
+        @planetFailMessage = 无法在此处进行采集
+    }
+}
+
+//CA-ET120 Solar Array
+@PART[ca_landv_sp]:AFTER[CoatlAerospace]
+{
+    @title = CA-ET120 太阳能阵列
+    @description = 这个太阳能电池板是轨道勘测者系列的一部分。纯种面板出厂时就已经被训练成尽可能追踪太阳，并且回应对其所有者的任何挑衅。如果您对它们产生“情感上或物理上”的依恋，保修将失效。我们的律师要求我们对此进行澄清。
+}
+
+//CA-SB15 Landvermesser Solid Rocket Retromotor
+@PART[ca_landv_srm]:AFTER[CoatlAerospace]
+{
+    @title = CA-SB15 勘测者固体燃料反推引擎
+    @description =  这个固体推力反推引擎用于进行普通离轨机动。它由一个由固体燃料组成的推进剂罐和一个反推引擎组成。
+}
+
+//CA-LV03 Landvermesser Vernier
+@PART[ca_landv_vernier]:AFTER[CoatlAerospace]
+{
+    @title = CA-LV03 勘测者微调发动机
+    @description =  这个小引擎是设计为安装在勘测者系列中，作为一组三个的集合。它是一种非常高效的早期设计，但非常脆弱，因此不能安装在堆栈上。
+}
+
+//===================================
+//子午线&天龙座（卡西尼号&惠更斯号）系列
+//===================================
+
+//CA-L1200 'Draco' Atmospheric Lander
+@PART[ca_draco]:AFTER[CoatlAerospace]
+{
+    @title = CA-L1200 "天龙座" 大气探测器
+    @description = 天龙座是一款非常坚固、防水且*但愿*具有浮力的探测器，专为大气层内着陆设计。紧凑的舱体内配备了电池、控制计算机、雷达测高仪、着陆相机以及一套完整的紧凑型大气分析设备。请注意，该探测器需要轨道中继器进行通信！（需单独购买）
+    //为该探测器添加休眠功能，延长与母探测器分离后的续航时间
+    @MODULE[ModuleCommand]
+    {
+        hasHibernation = True
+    }
+}
+
+//CA-MER-08 'Meridiani' Bus
+@PART[meridiani]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-08 子午线号核心
+    @description = 比我们的托雷卡探测器更大，子午线探测器是深空探测的下一步升级。紧凑的电子套件允许部分中空结构，便于安装设备。推进剂和额外功能由我们单独出售的子午线系列部件提供。请注意，如果用于撞击减速（岩石制动），保修将失效。
+}
+
+//CA-BCSS Draco Back Cover Subsystem
+@PART[ca_draco_as]:AFTER[CoatlAerospace]
+{
+    @title = CA-BCSS 天龙座号保护盖
+    @description = 天龙座探测器的隔热气动外壳在巡航过程中为着陆器提供全面保护，确保其安全抵达目的地。该系统采用高效的隔热材料抵御极端温度，并使用可靠的爆炸螺栓将后盖与隔热罩分离。经过多次测试和模拟验证，该机制表现稳定，未发生任何因分离过程导致的着陆器损坏情况。
+}
+
+//CAE-PD7-B Draco Drogue Parachute
+@PART[ca_draco_drogue]:AFTER[CoatlAerospace]
+{
+    @title = CAE-PD7-B 天龙座号减速伞
+    @description = 这款尼龙-凯夫拉尔材质的降落伞是基于我们富尔马赫着陆器系统的成功经验改进而来，专为天龙座着陆器系统设计。其独特的几何形状允许更多空气通过，有效减少了在稠密大气中的阻力效果。这一设计的优势在于，降落伞能够承受更高的速度和应力，允许在进入程序的更早阶段安全部署。
+}
+
+//CA-FRSS-200 Draco Front Shield Subsystem
+@PART[ca_draco_hs]:AFTER[CoatlAerospace]
+{
+    @title = CA-FRSS-200 天龙座号隔热罩
+    @description = CA-FRSS-200 天龙座前盾子系统采用AQ60瓦片盖，专为保护天龙座探测器在大气进入时的安全而设计。该系统结合了气动造型和高效烧蚀材料，能够在探测器进入大气层时有效转移由大气摩擦产生的热量和动能，确保隔热罩和上方的着陆器免受高温损害。
+}
+
+//CAE-P16-B Draco Parachute
+@PART[ca_draco_parachute]:AFTER[CoatlAerospace]
+{
+    @title = CAE-P16-B 天龙座号降落伞
+    @description = CAE-P16-B 天龙座降落伞采用尼龙-凯夫拉尔材料，基于我们Fomalhaut着陆器系统的成功经验改进而来，专为Draco着陆器系统设计。这款较轻的降落伞系统防护能力相对较低，主要依赖于Draco的气动外壳提供额外保护。其轻量化设计减少了整体重量，有助于提高着陆器的性能和灵活性，适用于需要减轻负载的任务。
+}
+
+//CA-MER-A400 Meridiani Dish Antenna
+@PART[mer_dish]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-A400 子午线号抛物线天线
+    @description = 强大的CA-MER-A400 子午线探测器天线专为从系统深处进行高效通信而设计。其内置雷达能够提供详细的KerbNet地形信息，支持精确的地形测绘和导航。需要注意的是，如果将此天线用作微陨石防护盾，保修将失效。通过右键菜单切换安装硬件和热箔覆盖。
+}
+
+//CA-MER-R4-D "Dominique" Liquid Fuel Engine
+@PART[mer_engine]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-R4-D "多米尼克" 液体燃料引擎
+    @description = 子午线航天器设计要求高度可靠的推进系统；为此我们推出了MER-R4-D(R4-D是现实中的卡西尼号探测器的主引擎)。这款采用高性能自燃推进剂并带有压力调节系统的引擎使用了最佳的建造材料，并配备了一个拥有完全功能的备用引擎以防止主引擎故障。即使您不使用备用引擎，也需要支付全额零售价格。
+}
+
+//CA-MER-FT140
+@PART[ca_mer_ft]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-FT140推进舱
+    @description =  CA-MER-FT140 是子午线系列的主要机身组件，集成了多种关键系统以支持深空探测任务。该组件不仅存储所有必要的推进剂，还内置了姿态控制推进器、电子设备、推进阀门、老人星星迹仪以及一个备用反应轮，确保在复杂任务中的稳定性和可靠性。紧凑的设计允许部分中空结构，便于安装其他设备，可以通过右键菜单切换防护罩。
+}
+
+//CA-MER-LEU Meridiani Lower Equipment Unit
+@PART[ca_mer_leu]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-LEU 子午线号下部设备单元
+    @description = CA-MER-LEU 是子午线系列的关键组件，集成了航天器的主要姿态控制动量轮、短程全向天线以及三个RTG的安装点。这种设计确保了在深空任务中的稳定姿态控制和可靠的电力供应。此外，还可以通过右键菜单切换RTG的防护罩，以适应不同的任务需求和环境条件。
+}
+
+//CA-MER-MAG300 Magnetometer Boom
+@PART[mer_mag]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-MAG300 磁强计
+    @description = CA-MER-MAG300 是一款先进的磁强计伸展臂，能够将双磁强计延伸数米远离航天器主体。该设计确保了磁强计远离航天器本身的磁场干扰，从而显著提高了测量的准确性。两个磁强计采用了不同的传感技术来收集数据，并通过交叉参考进一步提升了数据的可靠性和精确度。可以通过右键菜单切换金属箔。需要注意的是，这些磁强计仅在校准用于轨道环境中使用，确保在轨道任务中提供最准确的磁场测量数据。
+}
+
+//CA-DSA Draco Structural Adapter
+@PART[mer_ringDecoupler]:AFTER[CoatlAerospace]
+{
+    @title = CA-DSA 天龙座号结构适配器
+    @description = CA-DSA 天龙座探测器结构适配器是子午线探测器的天龙座分离装置和结构的独立组件，专为与其他母船配合使用而设计。该适配器采用可靠的爆炸螺栓技术来安全地释放着陆器有效载荷。最新设计显著降低了意外二次爆炸的风险，在一半的情况下可减少1%的发生概率，确保了分离过程更加平稳和安全。
+}
+
+//CA-MER-RSP Meridiani Remote Sensing Pallet
+@PART[mer_rsp]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-RSP 子午线遥感实验平台
+    @description = CA-MER-RSP 子午线探测器遥感实验平台是一组集成的相机和光谱仪组件，专门设计用于捕捉多个光谱波长的图像，以支持广泛的科学研究。该托盘配备了红外和紫外光谱仪，能够提供详细的光谱数据，适用于多种科学应用。此外，我们的合作伙伴AP光学提供的窄角和广角视觉相机进一步增强了系统的成像能力，确保可以从轨道上获取高分辨率的视觉图像。这一组合使得遥感托盘成为执行复杂科学任务的理想选择，无论是地球观测还是深空探测。
+}
+
+//CA-R8200 Advanced Radioisotope Thermoelectric Generator
+@PART[ca_mer_rtg]:AFTER[CoatlAerospace]
+{
+    @title = CA-R8200 高级放射性同位素热电发电机
+    @description = 这款高级RTG由我们的NERVA-HT核发动机设计团队——原子能研究部门为子午线系列产品开发。它采用了与NERVA-HT相同的蜘蛛状发电机，至少我们是这样被告知的。
+}
+
+//CA-MER-VLA Vehicle Launch Adapter
+@PART[mer_vla]:AFTER[CoatlAerospace]
+{
+    @title = CA-MER-VLA 航天器发射适配器
+    @description = 该载荷适配器专为子午线探测器和其他探测器设计，用于将有效载荷连接到发射火箭。爆炸螺栓在大多数情况下会分离有效载荷以执行任务。此外，还提供可选的单组元推进剂储存！
+}
+
+//================
+//沃罗纳(金星号)系列
+//================
+
+//CAE-PD7 Fomalhaut Drogue Parachute
+@PART[ca_fom_drogue]:AFTER[CoatlAerospace]
+{
+    @title = CAE-PD7 "南鱼座A" 减速伞
+    @description = 某些南鱼座A探测器大气进入剖面要求更早和/或更温和的减速。为此，我们设计了这款巨大且耐用的减速降落伞。警告：此降落伞不适合低触地速度。请做好迎接剧烈、颠簸着陆的准备。
+}
+
+//CAE-HS100 Fomalhaut Heat Shield
+@PART[ca_fom_heatS]:AFTER[CoatlAerospace]
+{
+    @title = CAE-HS100 "南鱼座A" 热防护盾
+    @description = 这是南鱼座A圆形外壳的底部组件（顶部部件为降落伞）。它涂有一层非常耐热的烧蚀材料，以防止内部设备因高温而受损。
+}
+
+//CAE-P16 Fomalhaut Parachute
+@PART[ca_fom_parachute]:AFTER[CoatlAerospace]
+{
+    @title = CAE-P16 "南鱼座A" 降落伞
+    @description = 这是南鱼座A圆形外壳的顶部组件。该降落伞直接连接到南鱼座A着陆器，在再入大气层后进行展开。大多数情况下，它能够成功展开。
+}
+
+//CAE-E175 Fomalhaut Solar Panel
+@PART[ca_fom_sp]:AFTER[CoatlAerospace]
+{
+    @title = CAE-E175 "南鱼座A" 太阳能电池板
+    @description = 这是一款小型基础太阳能电池板，设计为倾斜安装在南鱼座A着陆器的领圈上，用于为电池充电。
+}
+
+//CAE-SC-VIS Vorona Imaging System
+@PART[ca_vor_camera]:AFTER[CoatlAerospace]
+{
+    @title = CAE-SC-VIS 沃罗纳图像系统
+    @description = VIS 组件安装了一个完整的轨道成像套件，包括用于大气分析的紫外光谱仪、用于表面分析的红外光谱仪以及用于拍摄可见光范围内美观图像的紧凑型低分辨率望远镜相机。该组件提供了两种安装选项：与沃罗纳一起使用时为30度角，与其他设计和表面使用时为90度角。可以通过右键菜单进行切换。
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = 展开
+        @endEventGUIName = 收起
+        @actionGUIName = 切换
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_IRspec]]
+    {
+        @experimentActionName = 测量红外光谱
+        @resetActionName = 丢弃红外光谱数据
+        @collectActionName = 取走红外光谱数据
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_UVspec]]
+    {
+        @experimentActionName = 测量紫外光谱
+        @resetActionName = 丢弃紫外光谱数据
+        @collectActionName = 取走紫外光谱数据
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[scopeScan]]
+    {
+        @experimentActionName = 拍摄轨道成像
+        @resetActionName = 丢弃轨道成像数据
+        @collectActionName = 取走轨道成像数据
+    }
+}
+
+//CAE-A03 Vorona Communication Array
+@PART[ca_vor_comm]:AFTER[CoatlAerospace]
+{
+    @title = CAE-A03 沃罗纳通信阵列
+    @description = 沃罗纳通信阵列配备了双锥形天线，用于短距离、低增益通信。该系统还设有一个高增益碟形天线的安装接口，专为沃罗纳 CAE-102 高增益碟形天线设计（需单独购买）。
+}
+
+//CAE-102 Vorona Dish Antenna
+@PART[ca_vor_dish]:AFTER[CoatlAerospace]
+{
+    @title = CAE-102 沃罗纳高增益抛物面天线
+    @description =  沃罗纳抛物面天线配备了一个与其尺寸相比非常强大的发射器，能够在内太阳系中实现相当远的通信距离；无论您是否需要这种通信能力。
+}
+
+//CAE-LV175A "Kurt" Vorona Liquid Fuel Engine
+@PART[ca_vor_engine]:AFTER[CoatlAerospace]
+{
+    @title = CAE-LV175A "卡尔特" 沃罗纳液体燃料引擎
+    @description = 该发动机虽然较为紧凑，但比我们其他类似型号稍重且效率略低。然而，它在大气中的比冲 (ISP) 优于其他真空优化的引擎。较小的尺寸使其适合安装在狭小的空间内。
+}
+
+//CAE-MG03 Magnetometer 
+@PART[ca_vor_mag]:AFTER[CoatlAerospace]
+{
+    @title = CAE-MG03 沃罗纳磁强计
+    @description = 这是一款高科技设备，用于检测和测量磁场。请注意，它并非用于寻找水源的探水杆；如需购买探水杆，请联系 Coatl 园艺部门。任何关于探水为伪科学的说法均为想象或虚构。与任何实际说法的相似之处，无论是否经过证实，纯属巧合。
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @deployingMessage = 正在测量磁场...
+        @customFailMessage = 该磁强计仅用于太空使用
+        @endEventGUIName = 收起磁强计
+        @startEventGUIName = 展开磁强计
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 测量磁场
+        @resetActionName = 丢弃磁场数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CAE-MT12 MonoPropellant Fuel Tank
+@PART[ca_vor_mptank]:AFTER[CoatlAerospace]
+{
+    @title = CAE-MT12 单组元推进剂燃料箱
+    @description = 这个单组元推进剂储罐相当大！它可以承受比其他储罐更强的冲击，但我们仍然建议不要将其作为着陆支架使用。
+}
+
+//CAE-SAR15 Synthetic-Aperture Radar System
+@PART[ca_vor_sar]:AFTER[CoatlAerospace]
+{
+    @title = CAE-SAR15 合成孔径雷达系统
+    @description = 我们的合成孔径雷达系统可以提供比同类“100% 有机孔径雷达”替代品更好的高度计数据和更多的资源数据，不要被误导！两个锥形天线可以提供短距离通信。不含任何添加剂。我们自豪地在制造过程中仅使用自由范围的塑料和金属。
+}
+
+//CAE-D13-F Stack Decoupler
+@PART[ca_vor_sep1]:AFTER[CoatlAerospace]
+{
+    @title = CAE-D13-F 分离器
+    @description = 该分离器用于连接两部分，并在需要时分离。许多高质量部件由 Kaiwan 制造！
+}
+
+//CAE-E600-A Vorona Solar-Thermal System
+@PART[ca_vor_sp]:AFTER[CoatlAerospace]
+{
+    @title = CAE-E600-A 沃罗纳太阳能电池板及散热系统组合
+    @description = 沃罗纳的太阳翼上安装了大型光伏电池板以及一个大型散热器用于冷却系统。
+}
+
+//CAE-E300 Vorona Solar-Thermal System
+@PART[ca_vor_sp2]:AFTER[CoatlAerospace]
+{
+    @title = CAE-E300 沃罗纳太阳能电池板及散热系统组合
+    @description = 这种沃罗纳光伏电池板的替代装配方案卸下了一块面板，适用于需要较少电力的任务。
+}
+
+//CAE-LT98 Vorona Liquid Fuel Tank
+@PART[ca_vor_tank]:AFTER[CoatlAerospace]
+{
+    @title = CAE-LT98 沃罗纳液体燃料箱
+    @description = 这个非常坚固的燃料箱是沃罗纳轨道器系统的一部分。燃料箱的顶部有一个特殊的结构，可以容纳南鱼座A着陆器的球形胶囊，或者是非常大的蛋。
+}
+
+//CAE-L165 'Fomalhaut' Lander Probe
+@PART[ca_fom_lander]:AFTER[CoatlAerospace]
+{
+    @title = CAE-L165 "南鱼座A" 着陆探测器
+    @description = CAE 行星科学部门生产了这款坚固的“金属罐”，并配备了电池、辐射屏蔽、温度计、用于拍摄着陆点图像的相机以及顶部缠绕的天线。该探测器设计用于在极端环境中承受剧烈着陆。
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = 打开相机盖
+        @endEventGUIName = 关闭相机盖
+        @actionGUIName = 打开/关闭相机盖
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[temperatureScan]]
+    {
+        @experimentActionName = 测量温度
+        @resetActionName = 丢弃温度数据
+        @collectActionName = 取走温度数据
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_SiteSurvey]]
+    {
+        @experimentActionName = 拍摄着陆点图像
+        @resetActionName = 丢弃着陆点图像数据
+        @collectActionName = 取走着陆点图像数据
+    }
+
+}
+
+//CAE-200 'Vorona'
+@PART[ca_vor_core]:AFTER[CoatlAerospace]
+{
+    @title = CAE-200 "沃罗纳" 轨道器核心
+    @description = 沃罗纳探测系统设计用于与南鱼座A着陆器协同工作，以同时进行轨道和表面科学实验。它配备有电池、电子设备和单组元推进剂，并封装在一个非常坚固的外壳中。
+}
+
+
+
+//=======
+//天线部件
+//=======
+
+//CA-A02 Conic Antenna
+@PART[antenna_cone_toggle]:AFTER[CoatlAerospace]
+{
+    @title = CA-A02 锥形天线
+    @description  = 由于Kerbin上没有道路，我们能够购买大量多余的交通锥，并将它们全部改造成效率相当高的全向天线。通过切换按钮提供多种安装选项和颜色选择。
+}
+
+//CA-KPS KerbNet Position System Antenna
+@PART[ca_ant_gps]:AFTER[CoatlAerospace]
+{
+    @title = CA-KPS KerbNet 定位系统天线
+    @description = 该天线提供对KerbNet系统的访问，用于非常精确地跟踪航天器的位置。它可以作为全向天线使用，但功率不是很强。
+}
+
+//CA-A06 'Quetzal' Omni Antenna
+@PART[antenna_quetzal]:AFTER[CoatlAerospace]
+{
+    @title = CA-A06 "绿咬鹃"探测器全向天线
+    @description = 专为我们的 'Quetzal' 探测器系列设计的低增益天线。购买每台CA06探测器核心时免费赠送，只需支付单独的运费和处理费。此天线绝对不是用隔热箔包裹的损坏的通信者16天线。请将所有退货请求发送至离子电子质子交响乐的客户服务部门。
+}
+
+//CA-A01 Ground Plane Antenna
+@PART[antenna_tv]:AFTER[CoatlAerospace]
+{
+    @title = CA-A01 地面平面天线
+    @description = CA-A01 并不是一个普通的电视天线，而是一个航天级电视天线。警告：CA-A01 通过弹簧张力展开。请佩戴适当的眼睛保护装备！！！一旦展开，它将无法收回。
+}
+
+//CA-A10 Small Folding Relay Antenna
+@PART[dish_deploy_S]:AFTER[CoatlAerospace]
+{
+    @title = CA-A10 小型折叠中继天线
+    @description = CA-A10 提供了碟形天线的优势，而不会占用航天器前端的空间。发射期间，电动伺服系统会将天线折叠靠近船体。
+}
+
+//CA-AD1-R Small Folding Relay Antenna
+@PART[dish_deploy_S2]:AFTER[CoatlAerospace]
+{
+    @title = CA-AD1-R 小型折叠中继天线
+    @description = CA-AD1-R 中继碟形天线是同尺寸中最紧凑的天线之一。它提供了早期技术中继功能，能够快速启动任何航天计划的网络。
+}
+
+//CA-A190 Hera Dish Antenna
+@PART[dish_hera]:AFTER[CoatlAerospace]
+{
+    @title = CA-A190 "赫拉"探测器碟形天线
+    @description = （原型为朱诺号探测器高增益天线）尽管Hera的高增益天线尺寸较小，但其配备了非常强大的发射器。此外，碟形天线的边缘还安装了中增益和低增益天线以辅助工作。右键菜单中提供了隔热箔的切换选项。
+}
+
+//CA-A300 Torekka Relay Antenna
+@PART[dish_L]:AFTER[CoatlAerospace]
+{
+    @title = CA-A300 "托雷卡"探测器中继天线
+    @description = 该天线与 'Torekka' 探测器一同设计，具有比A200更大的带宽、更大的尺寸，并且效率更高，而重量几乎相同。注意：当与 'Torekka' 探测器配合使用时，请使用天线的顶部连接节点以启用其支架。
+}
+
+//CA-A200 Quetzal Relay Antenna
+@PART[dish_quetzal]:AFTER[CoatlAerospace]
+{
+    @title = CA-A200 "绿咬鹃"探测器中继天线
+    @description = CA-A200 专为与绿咬鹃探测器核心一起用于更远距离的任务而制造。这款复杂的天线内置了偏航和滚动 RCS（反应控制系统），并配备了一系列微流星体检测板。
+}
+
+//CA-A100 Small Dish Antenna
+@PART[dish_S]:AFTER[CoatlAerospace]
+{
+    @title = CA-A100 小型碟形天线
+    @description = CA-A100 是一款紧凑但高效的碟形天线，具有足够的范围，适用于Kerbol内系的使用。如果在Duna轨道之外使用，保修失效。
+}
+
+//CA-A180 Tatsujin Relay Antenna
+@PART[dish_tatsujin]:AFTER[CoatlAerospace]
+{
+    @title = CA-A180 "达人"探测器中继天线
+    @description = 这款天线体积小巧，但配备了强大的发射器以实现高带宽传输，不过牺牲了一部分传输距离。您可以通过右键菜单切换天线的护罩。
+}
+
+//CA-D02 Medium Folding Relay Antenna
+@PART[dish_xihe]:AFTER[CoatlAerospace]
+{
+    @title = CA-D02 中型折叠中继天线
+    @description = 这款中型碟形天线通过尽可能将碟面折叠靠近船体，降低了航天器包裹整流罩的大小。为了降低成本和尺寸，该天线不具备中继功能。
+}
+
+//===========
+//控制核心部件
+//===========
+
+//CA-V601 'Aegis'
+@PART[ca_aegis]:AFTER[CoatlAerospace]
+{
+    @title = CA-V601 '埃癸斯'探测器控制核心
+    @description = 这是目前最坚固、防护最强的探测器核心！它亲切地被称为“保险库”，Aegis 是与我们的Hera探测器核心一同设计的。Aegis 对辐射、干扰以及两岁小孩都有很强的防护能力。其强大的防护层虽然限制了额外功能的空间，但冗余的数据存储设施将确保珍贵的科学数据安全无虞。
+}
+
+//CA-Q02-M 'Barquetta'
+@PART[barquetta]:AFTER[CoatlAerospace]
+{
+    @title = CA-Q02-M "轻舟"探测器控制核心
+    @description =  轻舟是我们QBE系列中最小的总线模块，非常适合紧凑型科学任务或电信配置。其稳定系统由精细布置带有内置推进剂的RCS（反应控制系统）辅助。
+}
+
+//CA-602 'Hera'
+@PART[ca_hera]:AFTER[CoatlAerospace]
+{
+    @title = CA-602 "赫拉"探测器控制核心
+    @description =  赫拉是我们最大的探测器核心。预装了先进的星迹仪、电池、RCS（反应控制系统）和推进剂罐。内部组件使用坚固且特殊材料构建，以保护其免受恶劣的辐射带影响。
+}
+
+//CA06 'Quetzal'
+@PART[quetzal]:AFTER[CoatlAerospace]
+{
+    @title = CA-Q06 "格查尔"探测器控制核心
+    @description =  格查尔探测器控制核心是我们的首个商用设计，提供了开创性太空计划所需的所有基本控制功能。
+}
+
+//CA-Q04-M 'Tatsujin'
+@PART[tatsujin]:AFTER[CoatlAerospace]
+{
+    @title = CA-Q04-M "达人"探测器控制核心
+    @description =  介绍我们全新的、先进的QBE探测器总线。相比Barquetta，它的体积更大，容积增加了75%。专为大胆的科学任务设计，无论何时何地都能胜任。
+}
+
+//CA08-M 'Torekka'
+@PART[torekka]:AFTER[CoatlAerospace]
+{
+    @title = CA08-M "托雷卡"探测器控制核心
+    @description = 托雷卡是一款更大、更重且更为坚固的探测器核心，适用于长途航行。该控制器设计允许在中心位置安装单组元推进剂罐。遗憾的是，这种设计留给电池和稳定系统的空间非常有限。
+}
+
+//CA-Q20-M 'Xihe'
+@PART[xihe]:AFTER[CoatlAerospace]
+{
+    @title = CA-Q20-M "羲和" 探测器控制核心
+    @description = 最初为Kerbol科学合同委托设计的 'Xihe' 现已可用于其他任务。该探测器总线配备了冗余的单组元推进剂罐、动量轮和惯性测量单元，以确保长期运行的可靠性。次级RCS（反应控制系统）用于滚转控制。现在还配备了改进的环形激光陀螺仪和IMU(惯性测量单元)故障恢复程序！
+}
+
+//CA-T8E 'Explorer' Orbital Telescope
+@PART[ca_explorer]:AFTER[CoatlAerospace]
+{
+    @title = CA-T8E "探索者" 轨道望远镜
+    @description = 探索者是一款行业领先的成像系统，配备专用的紫外线传感器。包括内置电池、肼推进姿态系统和多个短程通信系统。总线电子设备围绕主光学系统组装，该系统校准用于长距离观测；尽管它也能进行低分辨率的轨道紫外线科学实验。航天器的后部有一个结构外壳，用于安装Stella 24C固体燃料发动机。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 测量紫外线光谱
+        @resetActionName = 丢弃测量紫外线光谱
+        @collectActionName = 取走数据
+    }
+}
+
+
+
+//=======
+//控制部件
+//=======
+
+//	title = CA-AACS Advanced Attitude Control System
+@PART[ca_aacs]:AFTER[CoatlAerospace]
+{
+    @title = CA-AACS 高级姿态控制系统
+    @description = 这个集成计算机系统利用两个星迹仪为航天器提供姿态方向信息。先进的软件运行在冗余的166 MHz处理器和640KB RAM上，这应该足以满足任何任务需求。系统还包含一个小容量的备用电池。
+}
+
+//CAE-RM01 RCS Thruster Block
+@PART[ca_RM01]:AFTER[CoatlAerospace]
+{
+    @title = CAE-RM01 RCS 推进器
+    @description = 这款双喷嘴推进器模块提供方向控制所需的RCS（反应控制系统）推力。拉长的喷嘴与我们Linkor服务舱中的设计相同，在真空中非常高效。
+}
+
+//CAE-RM02 RCS Thruster Block
+@PART[ca_RM02]:AFTER[CoatlAerospace]
+{
+    @title = CAE-RM02 RCS 推进器
+    @description = 这是改进型的RM01 RCS模块，其喷嘴朝向相反方向，专为旋转控制设计。拉长的喷嘴与我们Linkor服务舱中的设计相同，在真空中非常高效。
+}
+
+//CAE-RM03 RCS Thruster Block
+@PART[ca_RM03]:AFTER[CoatlAerospace]
+{
+    @title = CAE-RM03 RCS 推进器
+    @description = 我们的设计团队最初希望采用K形RCS喷嘴，但工程师们认为T形三向设计更易于制造和使用，并为此进行了争取。该模块可以与基于Linkor的设计相辅相成。
+}
+
+//CAE-RM04 RCS Thruster Block
+@PART[ca_RM04]:AFTER[CoatlAerospace]
+{
+    @title = CAE-RM04 RCS 推进器
+    @description = 这款四喷嘴RCS推进器模块专为小型到中型航天器的姿态控制系统提供辅助。它能够有效增强航天器的姿态控制精度和灵活性。
+}
+
+//CA-RS01 RCS Thruster Block
+@PART[ca_RS01]:AFTER[CoatlAerospace]
+{
+    @title = CA-RS01 RCS 推进器
+    @description = 这款小型RCS系统在一个非常紧凑的包装中提供了方向推力。它适用于对空间要求严格的航天器，同时确保了高效的姿态控制。
+}
+
+//CA-RS04 RCS Thruster Block
+@PART[ca_RS04]:AFTER[CoatlAerospace]
+{
+    @title = CA-RS04 RCS 推进器
+    @description = 这款四喷嘴RCS推进器模块专为小型航天器的姿态控制系统提供辅助。它能够在紧凑的设计中提供精确的方向控制，增强航天器的姿态稳定性和操控性。
+}
+
+//CA-RST RCS Thruster Block
+@PART[ca_rst]:AFTER[CoatlAerospace]
+{
+    @title = CA-RST RCS 推进器
+    @description = 这款紧凑的单组元推进剂推进器可以单独点火一个喷嘴作为方向控制RCS（反应控制系统），也可以同时点火三个喷嘴作为发动机使用。它为小型航天器提供了灵活的姿态和轨道调整能力。
+}
+
+//CA-RW3 Reaction Wheel Assembly
+@PART[ca_rw_large]:AFTER[CoatlAerospace]
+{
+    @title = CA-RW3 动量轮组件
+    @description = CA-RW3 动量轮组件是为中大型航天器设计的高扭矩动量轮系统。它提供了卓越的姿态控制精度和稳定性，适用于需要精细姿态调整的任务。该组件能够有效减少对RCS推进系统的依赖，从而节省宝贵的推进剂。
+}
+
+//CA-RW2 Reaction Wheel Assembly
+@PART[ca_rw_medium]:AFTER[CoatlAerospace]
+{
+    @title = CA-RW2 双动量轮
+    @description = 经过大量研究，我们发现提高性能的有效方法之一是——嗯，不是增加更多助推器，而是使用更多的动量轮。这里提供的是一个双动量轮组件，旨在提供更佳的姿态控制效果。
+}
+
+//CA-RW1 Reaction Wheel
+@PART[ca_rw_small]:AFTER[CoatlAerospace]
+{
+    @title = CA-RW1 动量轮
+    @description = CA-RW1 动量轮是专为小型航天器设计的紧凑型姿态控制组件。它提供了精确的姿态调整能力，适用于需要稳定和精细控制的任务。该动量轮易于集成到各种航天器平台中，确保了高效的姿态稳定性和控制性能。
+}
+
+//CA-RW1a Reaction Wheel
+@PART[ca_rw_xsmall]:AFTER[CoatlAerospace]
+{
+    @title = CA-RW1a 动量轮
+    @description = 制造技术的进步使我们能够将RW1型号的性能提升近50%，同时减小了体积。感谢您的支持。
+}
+
+//CA-ACS 'Startrack' Attitude Control System
+@PART[ca_startrack]:AFTER[CoatlAerospace]
+{
+    @title = CA-ACS "星轨"姿态控制系统
+    @description = CA-ACS 'Startrack' 姿态控制系统是一个集成的计算机系统，利用两个星迹仪为航天器提供精确的姿态方向信息。该系统采用先进的软件运行在冗余的166 MHz处理器和640 KB RAM上，足以满足任何任务需求。此外，系统还包含一个小容量的备用电池，以确保在电源故障时仍能维持关键功能。
+}
+
+//=======
+//电力部件
+//=======
+
+//CA-300i Battery
+@PART[ca_battery_l]:AFTER[CoatlAerospace]
+{
+    @title = CA-300i电池
+    @description = 300i是目前我们i系列中最大的电池。它配备了六个高性能可充电单元，能够满足您所有的电力需求！
+}
+
+//CA-100i Battery
+@PART[ca_battery_m]:AFTER[CoatlAerospace]
+{
+    @title = CA-100i电池
+    @description = 我们的双电池组设计高效、轻便且耐用。它配备了两个高性能电池单元，可以通过外部电源多次充电而不会损失性能，确保长时间使用的可靠性和稳定性。此产品的保修仅在Kerbin有效。
+}
+
+//CA-25i Battery
+@PART[ca_battery_s]:AFTER[CoatlAerospace]
+{
+    @title = CA-25i电池
+    @description = 这是我们i系列电池中最小的一款，采用超轻、低矮外壳设计，专为紧凑型和轻量化需求而优化。其小巧的尺寸和轻便的重量使其成为对空间和重量有严格要求的任务的理想选择。
+}
+
+//CA-R2000 Radioisotope Thermoelectric Generator
+@PART[ca_rtg2000]:AFTER[CoatlAerospace]
+{
+    @title = CA-R2000 放射性同位素热电发电机
+    @description = 为前往距离太阳遥远且太阳能板发电效率太低的地方，全新的R系列电力发电机通过利用放射性衰变释放的热量，在外Kerbol系统的极端环境中提供可靠且持续的电力供应。内置吊杆设计确保其远离敏感电子设备，保障任务的安全性和稳定性。虽然我们开玩笑地说是“竞争对手的灵魂”，但实际上是经过严格测试和认证的放射性燃料。
+}
+
+//CA-R3900 Radioisotope Thermoelectric Generator
+@PART[ca_rtg3900]:AFTER[CoatlAerospace]
+{
+    @title = CA-R3900 放射性同位素热电发电机
+    @description = 借助热电偶技术的最新进展，我们成功开发了三重RTG组件，专为更遥远的深空任务设计。这款发电机不仅提供了强大的电力支持，还配备了温度计以实时监控工作温度，并设有一个用于连接DMagic磁力仪的安装点，便于进行磁场测量。无论是在极端环境还是长时间任务中，CA-R3900都能确保可靠且持续的电力供应。
+}
+
+//CA-E320 1x2 Solar Panel
+@PART[sp_express_a]:AFTER[CoatlAerospace]
+{
+    @title = CA-E320 1x2太阳能板
+    @description = 1x2的太阳能板是CA-E系列中最小的一款，采用超轻、低矮外壳设计，专为紧凑型和轻量化需求而优化。其小巧的尺寸和轻便的重量使其成为对空间和重量有严格的要求且需要快速响应的任务的理想选择。
+}
+
+//CA-E340 1x4 Solar Panel
+@PART[sp_express_b]:AFTER[CoatlAerospace]
+{
+    @title = CA-E340 1x4太阳能板
+    @description = CA-E340 太阳能电池板的光伏面板数量是E300A的两倍，但价格仅增加一倍。这款电池板非常适合那些对电力需求较高的任务，提供显著增强的电力输出，确保您的探测器在长时间任务或高能耗应用中始终保持充足的能量供应。此外，其紧凑的设计使其易于集成到各种航天器配置中。
+}
+
+//CA-E12MG 1x3 Solar Panel and Magnetometer
+@PART[sp_juno_mag]:AFTER[CoatlAerospace]
+{
+    @title = CA-E12MG 1x3太阳能板与磁强计组合
+    @description = 为了支持前往Jool轨道的科学任务，我们设计了这款巨大的太阳能电池板。相比放射性同位素热电发电机（RTG），这些电池板不仅降低了成本，还减少了环境影响。尽管由于其较大的质量，当前版本的电池板无法自动追踪太阳，但我们正在积极研发这一功能。此12MG型号特别之处在于，它用一个非常灵敏的磁强计替换了外侧的一张光伏面板，为磁场测量提供了卓越的支持。
+}
+
+//CA-E12c 1x4 Solar Panel
+@PART[sp_juno]:AFTER[CoatlAerospace]
+{
+    @title = CA-E12c 1x4 太阳能电池板
+    @description = 为了支持前往Jool轨道的科学任务，我们设计了这些巨大的太阳能电池板！相比放射性同位素热电发电机（RTG），这些电池板不仅降低了成本，还减少了环境顾虑。由于其较大的质量，当前版本的电池板无法自动追踪太阳，但我们正在积极研发这一功能。
+}
+
+//CA-E100 1x2 Solar Panel
+@PART[sp_mariner_a]:AFTER[CoatlAerospace]
+{
+    @title = CA-E100 1x2 太阳能电池板
+    @description = 推出我们的E系列太阳能电池板！CA-E100 1x2太阳能电池板虽然体积较大，但结构非常坚固，能够在各种环境下稳定工作。它使您能够利用阳光为电池充电，几乎免费获取能源（*请注意，购买成本不包括在内）。这款电池板非常适合需要可靠电力支持的任务，确保您的探测器在长时间任务中始终保持充足的能量供应。
+}
+
+//CA-E100-SPV 1x2 Solar Panel
+@PART[sp_mariner_b]:AFTER[CoatlAerospace]
+{
+    @title = CA-E100-SPV 1x2 太阳能电池板
+    @description = 推出我们的E系列太阳能电池板！我们的科学家告诉我们，这些可选的太阳压板（Solar Pressure Vanes）可以为您的航天器提供+1魅力值和+1抗翻滚能力加成。
+}
+
+//CA-E400MG 1x2 Solar Panel
+@PART[sp_maven]:AFTER[CoatlAerospace]
+{
+    @title = CA-E400MG 1x2 太阳能电池板
+    @description = 这款先进的海鸥翼太阳能电池板系统在远距离时提供卓越的阳光捕捉和电力输出，但不具备太阳追踪功能。为了完善设计，我们在面板末端安装了紧凑型磁强计。
+}
+
+//CA-E200 3x1 Solar Panel
+@PART[sp_odyssey_a]:AFTER[CoatlAerospace]
+{
+    @title = CA-E200 3x1 太阳能电池板
+    @description = 这款CA-E200 3x1太阳能电池板是一款非常高效的光伏阵列，采用独特的偏心旋转点设计，能够在折叠时显著减小占用空间，不仅提高了存储和运输的便利性，还在某些航天爱好者社交圈中为您赢得酷炫加分。然而，请注意其非常低的离地间隙，在安装和操作时需格外小心，以避免与周围结构发生碰撞。
+}
+
+//CA-E200B 1x2 Solar Panel
+@PART[sp_odyssey_b]:AFTER[CoatlAerospace]
+{
+    @title = CA-E200B 1x2 太阳能电池板
+    @description = 在收到用户提出的多项改进建议后，我们的工程师基于屡获殊荣的E200系列，设计了一款全新的CA-E200B 1x2太阳能电池板。这款电池板显著改善了离地间隙，确保在安装和操作过程中更加安全可靠。此外，它继承了E200系列的所有优点，提供高效的电力输出和紧凑的设计。
+}
+
+//CA-E140 1x2 Advanced Solar Panel
+@PART[sp_stereo]:AFTER[CoatlAerospace]
+{
+    @title = CA-E140 1x2 高级太阳能电池板
+    //*该部件原先无部件描述，目前部件描述为译者后补充描述
+    @description = 这款CA-E140 1x2高级太阳能电池板结合了最新的光伏技术和创新设计，旨在为各种航天任务提供卓越的电力支持。它具备高效的能量转换率和紧凑的设计，确保在有限的空间内实现最大化的电力输出。此外，该电池板经过严格测试，能够在极端环境下保持稳定性能。
+}
+
+//CA-E300t Explorer Solar Panel
+@PART[ca_explorer_solar]:AFTER[CoatlAerospace]
+{
+    @title = CA-E300t "探索者"望远镜太阳能电池板
+    @description = 更先进的光伏电池覆盖了我们探索者望远镜系列的太阳电池板。3合1阵列设计为在收起时能紧贴船体，以获得最佳的收纳空间。这使得电池板能够在更多的角度下接收阳光；如果阳光追踪系统失效，也能提供一定的电力支持。
+}
+
+//=============
+//引擎&燃料箱部件
+//=============
+
+//CA-MV04 "Jib" MonoPropellant Engine
+@PART[ca_jib]:AFTER[CoatlAerospace]
+{
+    @title = CA-MV04 "三角帆" 单组元推进引擎
+    @description = 尽管其名字带有航海的遗产（暗示“Jib”这个词通常用于指代一种船帆），但实际上它的推力可能还不如帆的力量大。不过，这种内置发动机对于轻型飞行器仍然有用，并且可以表面安装以提供设计上的灵活性。
+}
+
+//CA-LV10 "Lahar" Liquid Fuel Engine
+@PART[ca_lahar]:AFTER[CoatlAerospace]
+{
+    @title = CA-LV10 "泥石流" 液体燃料引擎
+    @description = 骑上这波浪！我们小巧的LV10发动机专为出色的真空性能而设计。非常适合小型航天器的轨道修正和入轨操作。该发动机支持多次重启，其中一些重启可能是有意为之。
+}
+
+//CAE-LV35 "Linkor" Service Module
+@PART[ca_linkor]:AFTER[CoatlAerospace]
+{
+    @title = CAE-LV35 "联克" 服务舱
+    @description = 联克是我们超级紧凑的服务舱，内置真空环境下工作的引擎、用于精细控制的RCS系统以及自带推进剂！中部连接节点适用于较小的有效载荷，顶部连接节点适用于较大的有效载荷。
+}
+
+//CA-MV15 "Trident" MonoPropellant Engine
+@PART[ca_trident]:AFTER[CoatlAerospace]
+{
+    @title = CA-MV15 "三叉戟" 单组元推进引擎
+    @description = 当一群手持长矛的愤怒群众包围了他的办公室时，我们的首席工程师突发奇想，设计了一款三叉形的三喷嘴发动机，使用了三个CA-MV4发动机！
+}
+
+//CA-SRB-24C Stella 24C Solid Rocket Motor
+@PART[ca_stella24C]:AFTER[CoatlAerospace]
+{
+    @title = CA-SRB-24C Stella 24C 固体火箭发动机
+    @description = 这款小型真空环境下工作的Stella系列发动机最初是与我们的Explorer望远镜一同设计的。Stella系列发动机采用钛合金外壳，确保最高品质。内置抛弃系统，并采用了我们在餐巾纸上发现的SolidSAFE技术。
+}
+
+//CA-LT80 “Double” Liquid Fuel Tank
+@PART[ca_tank_lfo_m]:AFTER[CoatlAerospace]
+{
+    @title = CA-LT80 "双倍" 液体燃料箱
+    @description = 买一送一，内含两种液体！饮用任何一种均不推荐。可以通过中部连接节点（靠近底部）安装在飞船内部，或用于常规堆叠。
+}
+
+//CA-MT170 “Single” MonoPropellant Fuel Tank
+@PART[ca_tank_mp_m]:AFTER[CoatlAerospace]
+{
+    @title = CA-MT170 "单倍" 单组元燃料箱
+    @description = 可容纳大量单一液体。可以通过中部连接节点（靠近底部）安装在飞船内部，或用于常规堆叠。不建议用于烘焙。
+}
+
+//CA-MT10 MonoPropellant Fuel Bottle
+@PART[ca_tank_mp_s]:AFTER[CoatlAerospace]
+{
+    @title = CA-MT10 单组元推进剂箱
+    @description = 结果证明，潜水设备的坚固程度足以应对太空环境！这些紧凑的径向燃料瓶已经告别了它们的水肺潜水生涯，现在可以携带少量单组元推进剂，以备不时之需。
+}
+
+//CA-TPM-37E Torekka Propulsion Module
+@PART[ca_torekkaPM]:AFTER[CoatlAerospace]
+{
+    @title = CA-TPM-37E "托雷卡"探测器 推进模块
+    @description = 托雷卡推进模块连接到其适配桁架上。该系统由我们改进版的 Stella-37E 固体发动机提供动力。内置的 RCS 用于机动引导（因为 Stella 发动机不摆动），但单组元推进剂并未包含！集成的分离器默认情况下是禁用的，可以通过右键菜单进行分离。
+}
+
+//=======
+//科学仪器
+//=======
+
+//CA-SC103 Accelerometer
+@PART[ca_accelerometer]:AFTER[CoatlAerospace]
+{
+    @title = CA-SC103 加速度计
+    @description = SC103 配备了高灵敏度传感器，能够检测地震振动和加速度。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 记录地震数据
+        @resetActionName = 丢弃地震数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-SC102 Barometer
+@PART[ca_barometer]:AFTER[CoatlAerospace]
+{
+    @title = CA-SC102 气压计
+    @description = SC102 配备了一个内部气压探针，可以展开以测量当地大气压力，无论是作用在我、你还是你的航天器上的压强。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 记录压强数据
+        @resetActionName = 丢弃压强数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-DUST-C Dust Collector
+@PART[ca_DUSTC]:AFTER[CoatlAerospace]
+{
+    @title = CA-DUST-C 宇宙粉尘收集器
+    @description = DUST-C 配备了凝胶涂层收集器，用于捕捉尘埃颗粒并将其带回Kerbin进行分析。坚固的外壳绝不是华夫饼机，并且能够承受三种不同类型的热量以确保样本安全返回。请注意，此实验装置必须被带回Kerbin。
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @endEventGUIName = 关闭盖子
+        @startEventGUIName = 打开盖子
+        @toggleEventGUIName = 打开/关闭
+        @collectActionName = 获取尘埃样本
+        @experimentActionName = 收集尘埃数据
+        @resetActionName = 丢弃尘埃数据
+        @reviewActionName = 查看尘埃数据
+        @customFailMessage = 无法采集样本！
+        @deployingMessage = 正在收集尘埃...
+        @planetFailMessage = 无法在此处收集尘埃！
+    }
+}
+
+//CA-DUST-X Dust Experiment
+@PART[ca_dustX]:AFTER[CoatlAerospace]
+{
+    @title = CA-DUST-X 尘埃实验装置
+    @description = 由望远镜管改造而成，DUST-X 能够将收集到的尘埃颗粒引导至内置实验室进行飞行中分析。尽管如此，仍建议在Kerbin上进行全面分析。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 分析尘埃粒子
+        @resetActionName = 丢弃尘埃数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-ELIX Electrostatic Science
+@PART[ca_ELIX]:AFTER[CoatlAerospace]
+{
+    @title = CA-ELIX 电离与静电实验装置
+    @description = ELIX起源于一次失败的尝试，原本是想制造一个检测门把手静电荷的探测器。结果，这个电离与静电实验装置（ELIX）却非常擅长检测行星大气中的电荷和离子化粒子。ELIX可以在低轨道运行，也可以直接在电离层中使用。
+    @MODULE[DmoduleScienceAnimateGeneric]
+    {
+        @endEventGUIName = 收回
+        @startEventGUIName = 展开
+        @toggleEventGUIName = 切换模式
+        @collectActionName = 收集电离数据
+        @experimentActionName = 测量离子化电荷
+        @resetActionName = 丢弃数据
+        @reviewActionName = 查看电离数据
+        @transmissionWarningText = 无法传输数据
+        @customFailMessage = 无法运行静电测量！
+        @deployingMessage = 正在进行静电测量...
+        @planetFailMessage = 无法在此处运行静电测量！
+
+    }
+}
+
+//CA-SC104 Gravity Wave Detector
+@PART[ca_gravioli]:AFTER[CoatlAerospace]
+{
+    @title = CA-SC104 重力波探测器
+    @description = 结果证明，重力是阻止我们的火箭直线上升的原因。这款精密仪器能够测量重力场和重力波。看来阿尔伯特· 科曼（Albert Kerman）并不是疯子……
+    @MODULE
+    {
+        @experimentActionName = 记录重力数据
+        @resetActionName = 丢弃重力数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-GRS Gamma Ray Spectrometer
+@PART[ca_GRS]:AFTER[CoatlAerospace]
+{
+    @title = CA-GRS 伽马射线光谱仪
+    @description = 我们不确定为什么科学家们在阿尔法或贝塔射线光谱仪之前就想要一个伽马射线光谱仪（GRS），但这里它来了！该仪器对氢谱特别敏感，以便定位水源。
+    @MODULE[DmoduleScienceAnimateGeneric]
+    {
+        @deployingMessage = 正在展开扫描仪...
+        @customFailMessage = GRS不适合在大气飞行中使用，请在太空中再次尝试。
+        @endEventGUIName = 收回GRS
+        @startEventGUIName = 展开GRS
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 测量伽马射线谱
+        @resetActionName = 丢弃伽马射线数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-KLIR Infra-Red Spectrometer
+@PART[ca_KLIR]:AFTER[CoatlAerospace]
+{
+    @title = CA-KLIR 红外光谱仪
+    @description =  KLIR（Kerbal长程红外光谱仪）用于测量行星体的热辐射，可以计算表面温度甚至绘制表面特征图。该光谱仪还可以测量红外辐射的波长，以检测表面的特定元素。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 测量红外光谱
+        @resetActionName = 丢弃红外光谱数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-LUV Ultraviolet Spectrometer
+@PART[ca_LUV]:AFTER[CoatlAerospace]
+{
+    @title = CA-LUV 紫外线光谱仪
+    @description = LUV不仅仅是帮助提防晒霜建议，它还可以拍摄并分析短波紫外线光谱的图像，以突出表面特征并检测表面元素。不过，防晒霜的建议永远是“穿太空服”。
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = 展开
+        @endEventGUIName = 收回
+        @toggleEventGUIName = 切换模式
+    }
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 测量紫外线光谱
+        @resetActionName = 丢弃紫外线光谱数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-RPWS-S Radio-Plasma Wave Science
+@PART[ca_RPWS_STEREO]:AFTER[CoatlAerospace]
+{
+    @title = CA-RPWS-S 无线电等离子体波科学仪器
+    @description = 这款新型RPWS系统通过将电子设备安装在探测器内部而非外部，使得整体更加紧凑且外形更低矮。请注意，操作过程中造成的任何眼部伤害本公司概不负责。
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @deployingMessage = RPWS天线不适合在大气中或地面上使用，请在太空中再次尝试。
+        @customFailMessage = 天线收起后传感器无法读取任何数据，请先展开天线。
+        @endEventGUIName = 收回RPWS
+        @startEventGUIName = 展开RPWS
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 记录RPWS数据
+        @resetActionName = 丢弃数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-RPWS Radio-Plasma Wave Science
+@PART[ca_RPWS]:AFTER[CoatlAerospace]
+{
+    @title = CA-RPWS 无线电等离子体波科学仪器
+    @description = 科学设计团队没有随此部件附带规格文档。我们推测它测量广播电台的收听率和等离子电视的评论。在可伸缩天线附近请佩戴适当的眼部保护！
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @deployingMessage = RPWS天线不适合在大气中或地面上使用，请在太空中再次尝试。
+        @customFailMessage = 天线收起后传感器无法读取任何数据，请先展开天线。
+        @endEventGUIName = 收回RPWS
+        @startEventGUIName = 展开RPWS
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 记录RPWS数据
+        @resetActionName = 丢弃RPWS数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-SCB01 Torekka Science Boom
+@PART[ca_sciBoom]:AFTER[CoatlAerospace]
+{
+    @title = CA-SCB01 "托雷卡"探测器科学伸缩臂
+    @description = 我们为托雷卡探测器核心设计了这款科学伸缩臂。伸缩臂上安装了窄视场和宽视场相机，用于轨道调查成像，以及红外和紫外线光谱仪。展开伸缩臂可以将实验仪器远离探测器电子设备的干扰和辐射。
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = 展开
+        @endEventGUIName = 收回
+        @actionGUIName = 切换模式
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_IRspec]]
+    {
+        @experimentActionName = 测量红外光谱
+        @resetActionName = 丢弃红外光谱数据
+        @collectActionName = 取走数据
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_UVspec]]
+    {
+        @experimentActionName = 测量紫外光谱
+        @resetActionName = 丢弃紫外光谱数据
+        @collectActionName = 取走数据
+    }
+    @MODULE[ModuleScienceExperiment]:HAS[#experimentID[ca_orbitalScope]]
+    {
+        @experimentActionName = 拍摄轨道图像
+        @resetActionName = 丢弃轨道图像数据
+        @collectActionName = 取走数据
+
+    }
+    
+}
+
+//CA-MSW-150 Xihe Science Boom
+@PART[ca_MSW150]:AFTER[CoatlAerospace]
+{
+    @title = CA-MSW150 "羲和"探测器科学伸缩臂
+    @description = 羲和的科学伸缩臂携带一个非常紧凑的磁强计和一个新型实验性太阳风实验装置，该装置可以检测和测量太阳等离子体中的电子。虽然这是早期技术，但我们希望它能够取得成功！
+    @MODULE[DMmoduleScienceAnimateGeneric]
+    {
+        @deployingMessage = 正在展开磁强计...
+        @customFailMessage = 磁强计仅用于太空使用
+        @endEventGUIName = 收回磁强计
+        @startEventGUIName = 展开磁强计
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 记录磁场数据
+        @resetActionName = 丢弃磁场数据
+        @collectActionName = 取走数据
+    }
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 记录太阳风数据
+        @resetActionName = 丢弃太阳风数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-SWIS Solar Wind Analyzer
+@PART[ca_SWIS]:AFTER[CoatlAerospace]
+{
+    @title = CA-SWIS 太阳风分析仪
+    @description = 当太阳风在互联网上开始流行时，科学家们意识到现有的气象仪器无法检测到它。我们的太阳风科学（SWIS）仪器专门设计用于检测和测量太阳风数据。敬请期待我们的太阳风风铃，即将推出！
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 记录太阳风数据
+        @resetActionName = 丢弃太阳风数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-ROTFL Orbital Telescope
+@PART[ca_telescope]:AFTER[CoatlAerospace]
+{
+    @title = CA-ROTFL 轨道望远镜
+    @description = ROTFL（Reconnaissance Orbital Telescoping Focusing Lens）是一款先进的Kerman-Kerman反射望远镜，用于拍摄地面的近距离图像。镜头和软件经过轨道校准后使用，无法在地面上使用。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 拍摄轨道图像
+        @resetActionName = 丢弃轨道图像数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-SC100 Thermometer
+@PART[ca_thermometer]:AFTER[CoatlAerospace]
+{
+    @title = CA-SC100 温度计
+    @description = 掌握太空探索的第一步是知道在哪里打包毛衣，以及你的“坎巴拉人的第一步”是否会以你的脚和太空靴融化成一堆胶水而告终，这将让实验室里的男孩们兴奋不已。我们的温度计就是为此而设计的。
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentActionName = 测量温度
+        @resetActionName = 丢弃温度数据
+        @collectActionName = 取走数据
+    }
+    
+}
+
+//CA-MG100 Magnetometer Boom
+@PART[ca_magneto2]:AFTER[CoatlAerospace]
+{
+    @title = CA-MG100 磁强计
+    @description = 这个折叠伸缩臂的末端的主要部分安装了一个氦矢量磁强计，原本用于检测气球的位置。更正：实际上它用于测量磁场。
+    @MODULE[DMModuleScienceAnimateGeneric]
+    {
+        @deployingMessage = 正在展开磁强计...
+        @customFailMessage = 这个磁强计仅用于太空使用
+        @endEventGUIName = 收回
+        @startEventGUIName = 展开
+        @toggleEventGUIName = 切换模式
+        @experimentActionName = 记录磁场数据
+        @resetActionName = 丢弃磁场数据
+        @collectActionName = 取走数据
+    }
+}
+
+//CA-H2RS High-Resolution Radar System
+@PART[ca_H2RS]:AFTER[CoatlAerospace]
+{
+    @title = CA-H2RS 高分辨率雷达系统
+    @description = 该高分辨率雷达系统使用安装在3个支架上的6个天线来创建非常精确的雷达扫描图像。系统非常灵敏，能够追踪地表物体的方向和速度。它被设计用于监测KSC建筑之间车辆的速度（用于超速罚单）以及为再次发射卫星提供理由。双赢。
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = 展开
+        @endEventGUIName = 收回
+        @toggleEventGUIName = 切换模式
+    }
+}
+
+//CA-HOLA Laser Altimeter
+@PART[ca_HOLA]:AFTER[CoatlAerospace]
+{
+    @title = CA-HOLA 激光高度计
+    @description = 由于KSC飞行员不断在西边的山脉上发生撞山事故，我们被要求提供帮助。我们开发了一种仪器，试图通过从轨道上向山峰发射激光来降低他们的飞行高度。这个尝试完全失败了，但我们发现激光反射回来的时间间隔取决于海拔高度，因此诞生了高功率轨道激光测高仪。
+}
+
+//CA-TRIXIE Multi-spectral Imager
+@PART[ca_TRIXIE]:AFTER[CoatlAerospace]
+{
+    @title = CA-TRIXIE 多谱图像仪
+    @description = TRIXIE 配备了两个相机组件，可以成像和扫描从紫外线到近红外的多个光波段。这为从轨道上确定地表特征和生物群落提供了有效的方法。首席设计师 Ed Kerman 博士没有解释这个缩写的含义。此外，还有一个可选的保护罩，可以通过右键菜单进行切换。
+    @MODULE[DMmoduleScienceAnimate]
+    {
+        @experimentActionName = 记录成像数据
+        @resetActionName = 丢弃数据
+        @customFailMessage = 成像平台不适合在大气层内使用或表面部署，请尝试在太空中使用。
+        @startEventGUIName = 展开
+        @endEventGUIName = 收回
+        @toggleEventGUIName = 切换模式
+        @collectActionName = 取走数据
+    }
+
+}
+
+
+
+
+//=====
+//散热器
+//=====
+
+//CA-TCL8 Thermal Control Louver 
+@PART[ca_louver_m]:AFTER[CoatlAerospace]
+{
+    @title = CA-LVR100 百叶窗热控系统
+    @description = 百叶窗热控系统是一种热控制系统，可以通过暴露散热鳍和散热器来排出热量。打开通风口以释放航天器中的热量。该系统比TCL4-B的高度和性能翻倍，提供更好的冷却效果。
+}
+
+//CA-TCL4 Thermal Control Louver 
+@PART[ca_louver_s]:AFTER[CoatlAerospace]
+{
+    @title = CA-TCL4 百叶窗热控系统
+    @description = 百叶窗热控系统是一种热控制系统，可以通过暴露散热鳍和散热器来排出热量。打开通风口以释放航天器中的热量。这是标准尺寸的系统。
+}
+
+//CA-TCL4-B Thermal Control Louver 
+@PART[ca_louver_s2]:AFTER[CoatlAerospace]
+{
+    @title = CA-TCL4-B 百叶窗热控系统
+    @description = 百叶窗热控系统是一种热控制系统，可以通过暴露散热鳍和散热器来排出热量。打开通风口以释放航天器中的热量。这是TCL4的另一种较长版本。
+}
+
+//===========
+//其他类型部件
+//===========
+
+//CA-T2A-R33 Torekka Truss Adapter
+@PART[ca_torekka_truss]:AFTER[CoatlAerospace]
+{
+    @title = CA-T2A-R33 "托雷卡"探测器 桁架适配器
+    @description = 该结构件安装在托雷卡控制核心的底部，用于安全可靠地连接其推进模块。我们的工程师还集成了一个分流散热器，它具有双重功能。虽然我们对分流技术非常自信，并且拥有最佳的分流解决方案，但这里的主要功能是确保稳定性和高效散热。如果您有任何疑问，请随时联系我们。
+}
+
+//CA-ESM Quetzal Extended Service Module
+@PART[ca_ESM]:AFTER[CoatlAerospace]
+{
+    @title = CA-ESM "绿咬鹃"探测器 扩展服务模块
+    @description = ESM 为长距离探险提供了必要的支持功能。它配备了额外的电池、动量轮、热控系统和单组元推进剂罐。
+}
+
+//CA-ESM2 Quetzal Extended Service Module
+@PART[ca_ESM2]:AFTER[CoatlAerospace]
+{
+    @title = CA-ESM2 "绿咬鹃"探测器 扩展服务模块
+    @description = 当生活给你柠檬（或工厂生产的故障绿咬鹃探测器）时，学会制作柠檬水（在其中安装燃料箱、电池和新电子设备）。这样可以变废为宝！
+}
+
+//=======================
+//--------科学报告--------
+//=======================
+@EXPERIMENT_DEFINITION:HAS[#id[ca_gammaRay]]:AFTER[CoatlAerospace]
+{
+    @title = 伽马射线光谱测量
+    @RESULTS
+    {
+        @default = 您正在测量伽马射线辐射。
+        @default = 您正在扫描氢元素特有的伽马射线光谱。
+        @default = 光谱仪开始扫描元素沉积。
+
+        @SunInSpace = 传感器确认：Kerbol（太阳）发射伽马辐射。
+        @SunInSpaceLow = 日冕抛射伴随着伽马射线的急剧增加。
+        @SunInSpaceLow = 检测到巨大的伽马射线峰值，可能来自太阳耀斑。
+        @SunInSpaceHigh = 即使在长距离下也能检测到Kerbol的伽马辐射。
+        @SunInSpaceHigh = 该仪器记录了此高度的伽马射线水平。
+
+        @MohoInSpace = 完成了Moho附近的伽马射线水平测量！
+        @MohoInSpaceLow = 在Moho表面检测到了铁矿石。
+        @MohoInSpaceLow = 详细扫描揭示了极地陨石坑阴影中的冻结水。
+        @MohoInSpaceHigh = 在极地检测到了微量的冻结水。
+        @MohoInSpaceHigh = GRS测量了辐射水平。实验室技术人员需要确定这些辐射是来自Moho还是Kerbol。
+
+        @EveInSpace = 记录了Eve周围的伽马射线水平。
+        @EveInSpaceLow = 来自下方湖泊的伽马辐射表明它们含有某种挥发性液体。
+        @EveInSpaceLow = 如果Eve曾经有大量的水，它们一定很久以前就蒸发掉了。
+        @EveInSpaceHigh = 不同的云层被检测到吸收和反射不同量的由Kerbol发出的伽马射线。
+        @EveInSpaceHigh = 在云层中检测到了一些天然放射性元素的痕迹。
+
+        @GillyInSpace = GRS测量了Gilly暴露于伽马射线的情况。
+        @GillyInSpaceLow = 在表面检测到了铁和硅酸盐的痕迹。
+        @GillyInSpaceHigh = Gilly的伽马射线水平与小行星周围的检测结果相似。
+
+        @KerbinInSpace = 从Kerbin周围获取了伽马射线光谱测量。
+        @KerbinInSpaceLow = 确认Kerbin的大气层保护表面免受大量伽马辐射。
+        @KerbinInSpaceLow = 检测到了Kerbin的海洋、湖泊和河流。
+        @KerbinInSpaceLow = 这种先进的仪器真的有必要用来确认Kerbin有大量水吗？
+        @KerbinInSpaceHigh = 由于大气层提供的保护，Kerbin表面的伽马射线绘图很困难。
+        @KerbinInSpaceHigh = 记录伽马射线水平以建立生命所需条件的模板。
+
+        @MunInSpace = 光谱仪测量了Mun表面的伽马射线水平。
+        @MunInSpaceLow = 在表面检测到了铁的痕迹。
+        @MunInSpaceLow = 在极地检测到了与水存在一致的氢水平。
+        @MunInSpaceHigh = 与Kerbin相比，由于缺乏大气层，表面测量更容易进行。
+
+        @MinmusInSpace = 记录了Minmus的GRS测量数据。
+        @MinmusInSpaceLow = Minmus缺乏大气层也使得表面绘图更容易。
+        @MinmusInSpaceLow = Minmus似乎在其极地也有与水相关的氢浓度。
+        @MinmusInSpaceHigh = 完成了伽马射线光谱分析：开心果（注：此处可能是幽默或误译，通常应为具体成分）。
+
+        @DunaInSpace = 记录了Duna附近的伽马辐射水平。
+        @DunaInSpaceLow = 在极地检测到了以冰形式存在的水分子。
+        @DunaInSpaceLow = 在古老的火山山脉周围，硅含量显著较低。
+        @DunaInSpaceLow = 在低地检测到了氯的残余，暗示着古代湖泊的存在。
+        @DunaInSpaceHigh = 在Duna上检测到了大量的氧化铁。
+        @DunaInSpaceHigh = GRS数据允许对表面的几种元素进行绘图。
+        @DunaInSpaceLow = 在Duna表面发现了硅矿床。
+
+        @IkeInSpace = 记录了来自Ike的GRS数据。
+        @IkeInSpaceLow = 在表面检测到了硅的痕迹。
+        @IkeInSpaceHigh = 极地区域检测到水冰的趋势继续存在。
+
+        @DresInSpace = 系统记录了来自Dres表面的伽马射线光谱数据。
+        @DresInSpaceLow = Dres的组成似乎与Mun相似。
+        @DresInSpaceLow = 在表面发现了铁和硅的痕迹。
+        @DresInSpaceHigh = 伽马射线分析结果未能减少科学界的不信任。
+
+        @JoolInSpace = 由于其体积庞大，GRS数据结果从Jool处记录下来花费了一些时间。
+        @JoolInSpaceLow = Jool的大气层中确实含有相当数量的放射性物质。
+        @JoolInSpaceLow = GRS测量显示强Kerbol辐射与Jool高层大气之间的某种相互作用。
+        @JoolInSpaceHigh = Jool似乎反射或发射了大量的伽马射线。
+        @JoolInSpaceHigh = Jool的大气层中似乎含有大量的氢。
+
+        @LaytheInSpace = 收集了来自Laythe周围的GRS数据。
+        @LaytheInSpaceLow = Laythe含有大量的水和氯。
+        @LaytheInSpaceLow = 氯的水平可能表明空气中和水中存在盐分。
+        @LaytheInSpaceHigh = 发现了相当数量基于水的氢。
+        @LaytheInSpaceHigh = 收集的数据反映了与Kerbin非常相似的条件。
+
+        @VallInSpace = 收集了来自Vall周围的GRS数据。
+        @VallInSpaceLow = 氢读数来源于表面的冰火山活动。
+        @VallInSpaceHigh = Vall的空气中和陆地上都含有氢。
+
+        @TyloInSpace = 收集了Tylo的伽马射线光谱。
+        @TyloInSpaceLow = 表面没有检测到水，而是岩石较多。
+        @TyloInSpaceHigh = 扫描显示在陨石坑附近有分散的资源矿藏。
+
+        @PolInSpace = 收到了来自卫星Pol的GRS数据。
+        @PolInSpaceLow = 起伏多变的地形使得扫描变得困难，但似乎没有水存在。
+        @PolInSpaceHigh = 请稍等，计算机显示器上有污迹影响结果。
+
+        @BopInSpace = 伽马射线光谱仪扫描了Bop。
+        @BopInSpaceLow = 读数显示表面由碳和铁组成。
+        @BopInSpaceHigh = GRS扫描表明Bop含有碳、铁和...
+
+        @EelooInSpace = 测量了Eeloo的伽马射线辐射。
+        @EelooInSpaceLow = 检测到了大量的硅元素。
+        @EelooInSpaceLow = 微弱的背景伽马辐射被发现来自我们的母星Kerbol。
+        @EelooInSpaceHigh = Eeloo似乎被大量的冰覆盖。
+        @EelooInSpaceHigh = 光谱仪短暂地被高能伽马射线爆发所致盲。
+
+        //OPM
+
+        @SarnusInSpace = 该仪器记录了来自气态巨行星Sarnus周围的伽马射线辐射。
+        @SarnusInSpaceLow = 读数暗示在大气层较低层可能存在以冰形式存在的水。
+        @SarnusInSpaceLow = 测量用于微调Sarnus中氢含量的模型。这表明该巨行星的密度小于水！
+        @SarnusInSpaceHigh = Sarnus似乎由大量的氢组成。
+
+        @TektoInSpace = 记录了来自Tekto周围的伽马射线测量值。
+        @TektoInSpaceLow = 分析得出结论，检测到的氢不是来自水，而是其他富氢分子。
+        @TektoInSpaceLow = 简单的碳氢化合物被确认为检测到的氢的来源，并且主要集中在表面。
+        @TektoInSpaceLow = 从表面检测到了简单碳氢化合物的排放，可能是乙烷。
+        @TektoInSpaceLow = 记录了表面级别的烷烃碳氢化合物排放。水平似乎表明存在乙烷。
+        @TektoInSpaceHigh = 结果显示检测到了有希望水平的氢。
+        @TektoInSpaceHigh = 排放表明Tekto上存在氢。
+
+        @SlateInSpace = GRS未检测到任何氢的存在。
+        @SlateInSpace = 没有任何迹象表明表面或地下有任何形式的水。
+
+        @HaleInSpace = 氢水平与水冰的存在一致。
+        @HaleInSpace = 成分分析表明月球的大部分是由水冰构成。
+        @HaleInSpaceHigh = GRS测量表明该月球的成分与环非常相似。
+
+        @OvokInSpace = 氢水平与水冰的存在一致。
+        @OvokInSpace = 成分分析表明月球的大部分是由水冰构成。
+        @OvokInSpaceHigh = GRS测量表明该月球的成分与...（原文缺失）
+
+        @UrlumInSpace = 该仪器记录了来自气态巨行星Urlum周围的伽马射线辐射。
+        @UrlumInSpaceHigh = 伽马射线辐射与气态巨行星大气层和云层中大量存在的氢一致。
+        @UrlumInSpaceLow = 读数显示Urlum主要由氢组成。
+
+        @WalInSpaceLow = 在表面发现了铁和硅的痕迹。
+        @WalInSpaceHigh = 该仪器仅检测到少量的冰氢，可能是深陨石坑内的冻结水。
+
+        @TalInSpaceLow = GRS数据显示高冰量。
+        @TalInSpaceHigh = 该仪器检测到了大量的冰和金属。
+
+        @PriaxInSpaceHigh = 初步伽马射线测量未显示任何水或基于氢的分子。
+        @PriaxInSpaceLow = 进一步调查仍未产生任何明确的水冰迹象。
+
+        @PoltaInSpaceHigh = GRS检测到了表明存在不同状态水的氢排放。
+        @PoltaInSpaceLow = 光谱仪检测到了波动，暗示表面下可能存在液态海洋！
+        @PoltaInSpace = 检测到了作为冰和潜在咸水存在的水。
+
+        @NeidonInSpace = 从气态巨行星Neidon记录了一组优秀的伽马射线测量值。
+        @NeidonInSpaceHigh = 该仪器检测到了表明存在氢和甲烷的不同原子特征。
+        @NeidonInSpaceLow = Neidon的组成大约80%是氢，还有其他碳氢化合物和水。
+
+        @ThatmoInSpaceHigh = 该仪器未登记到任何显著的基于氢的分子存在。
+        @ThatmoInSpaceLow = 更接近的测量仅在表面附近检测到了微量的甲烷和其他碳氢化合物。
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_rpws]]:AFTER[CoatlAerospace]
+{
+    @title = 无线电与等离子体波扫描
+    @RESULTS:NEEDS[!DmagicOrbitalScience]
+    {
+        @default = 您测量了背景无线电和等离子体干扰。
+        @default = 对局部等离子体波进行了测量。
+        @default = 记录了无线电波和离子化粒子。
+        @default = 记录了无线电波和离子化粒子。这将是一段混乱的混音。
+
+        @SunInSpace = 星星在无线电波长范围内填充空间，产生可检测的背景辐射。
+        @SunInSpaceLow = 星星发出非常强大的无线电波。
+        @SunInSpaceHigh = 即使在这个距离，也检测到了带电粒子。
+
+        @MohoInSpace = 从Moho记录了无线电等离子体波数据。
+        @MohoInSpace = Moho没有大气干扰。
+        @MohoInSpace = *刺耳的静电和尖叫声*
+
+        @EveInSpace = Eve的强大磁场似乎在偏转大量离子化粒子。
+        @EveInSpaceLow = 对记录数据的分析暗示闪电是无线电干扰的原因。
+        @EveInSpaceHigh = 沿着Eve磁尾检测到了带电粒子。
+
+        @GillyInSpace = 记录的无线电干扰是由Eve偏转的粒子引起的。
+
+        @KerbinInSpace = 无线电干扰是由大气偏转引起的。
+        @KerbinInSpaceLow = 捕获到了一次激烈的科学辩论的无线电广播。不出所料，Kraken赢了。
+        @KerbinInSpaceLow = Kerbin大气层被发现偏转了大量粒子和长波无线电波。
+        @KerbinInSpaceHigh = 检测到了混合了偏转带电粒子的无线电信号。
+        @KerbinInSpaceHigh = *静电* 请离开这个频率... *静电*
+        @KerbinInSpaceHigh = 检测到了来自DSN天线的强大载波信号。
+
+        @MunInSpace = 对Mun周围的无线电等离子体记录进一步证实了其缺乏大气。
+        @MunInSpaceLow = 从Mun的暗面捕捉到了一个奇怪的信号 *静电* 太阳 *静电* 同样 *静电* 相对 *静电* 你老了 *静电*...
+
+        @MinmusInSpace = 检测到了离子化粒子以及来自Kerbin的背景无线电信号。
+        @MinmusInSpace = 检测到了从Kerbin偏转的无线电波，甚至到达了Minmus。
+
+        @DunaInSpace = 数据显示北半球存在一些局部无线电偏转或发射。
+        @DunaInSpace = 天线记录了一些低增益干扰，可能是由于稀疏的离子化粒子引起的间歇性反射。
+        @DunaInSpaceLow = 尽管其性质微弱，似乎在低层大气中发生了某种电离现象。
+
+        @IkeInSpace = 无线电波长分析显示干扰不是来自Ike或Duna。
+        @IkeInSpace = 记录显示只有由Jool或Kerbol引起的背景波。
+
+        @DresInSpace = 在这个距离仍然强烈检测到Kerbol的电磁辐射。
+        @DresInSpace = 波分析表明表面散射未受到任何大气的阻碍。
+
+        @JoolInSpace = 强大的磁场偏转了大量恒星的太阳辐射。
+        @JoolInSpaceLow = 行星磁层内部注册的波模式与外部有很大不同。
+        @JoolInSpaceHigh = Jool的磁场创造了独特的无线电波中断，这应该暗示其内部成分。
+
+        @LaytheInSpace = Jool的磁场似乎在其轨道上捕获了大量的等离子体。
+        @LaytheInSpace = 天线记录了一组由行星与Laythe之间强烈磁相互作用引起的无线电信号交响乐。
+        @LaytheInSpaceLow = 4, 8, 15, 16, 23, 42...  4, 8, 15, 16...
+
+        @VallInSpace = 由行星电离层产生的带电粒子继续在该高度回响。
+        @VallInSpace = 记录了来自Vall周围的无线电波数据。该行星仍然强烈影响这一频谱中的所有活动。
+
+        @TyloInSpace = 发现Tylo也主要被行星的磁场屏蔽。
+        @TyloInSpace = 检测到了在Tylo后面的微弱离子化粒子，可能是其轨道上偏转的。
+
+        @PolInSpace = Pol似乎与行星的带电粒子几乎没有相互作用。
+        @PolInSpace = 在此高度记录的行星背景回声似乎在社交媒体上很受欢迎，但科学价值不大。
+
+        @BopInSpace = 检测到了一个模糊地类似于摩尔斯电码的信号，但没有遵循任何可辨别的电子或自然模式。
+        @BopInSpace = 检测到的无线电信号似乎是飞船自身信号的严重退化回弹；可能是被行星磁场弓激波偏转的。
+
+        @EelooInSpace = 在Eeloo周围的背景波中没有检测到可识别的电离模式。
+        @EelooInSpace = 检测到了来自Kerbin DSN的非常微弱的信号。
+
+        @AsteroidInSpaceMettalic = 无线电波干扰表明小行星存在某种磁性迭代。
+        @AsteroidInSpaceStony = 小行星似乎与传播的波没有磁性相互作用。
+
+        //OPM
+
+        @SarnusInSpace = 分析了频率范围在50到500 kHz的无线电发射测量值，以通过其对带电粒子的周期性影响更准确地获得行星的自转速率。
+        @SarnusInSpace = 天线记录了随着磁场移动的无线电源发出的非常诡异的声音。
+        @SarnusInSpace = 发现Sarnus具有非常复杂的极其强大的无线电发射范围。
+        @SarnusInSpace = 对行星等离子体自转速率的测量给出了磁场线旋转速度的良好指示；因为等离子体直接受磁场影响。
+
+        @TektoInSpace = 记录显示月球上层大气的电离层结构和动力学受到Sarnus磁层的巨大影响。
+        @TektoInSpace = 月球上层大气中的原子和分子似乎被来自Kerbol和Sarnus磁层轰击的高能粒子电离。
+
+        @SlateInSpaceHigh = 仪器记录了来自行星的一些背景噪声。
+        @SlateInSpace = 检测到的一些噪声似乎是被Sarnus偏转或生成的等离子体发射。
+        @SlateInSpaceLow = 由于缺乏大气或活跃磁性，来自下方月球的记录交互非常少。
+
+        @HaleInSpaceHigh = 记录的扰动以与行星环相似的模式共振。
+        @HaleInSpaceLow = 测量几乎无法区分该月球与其所在的环。
+        @HaleInSpace = 仪器记录了来自行星的一些背景噪声。
+
+        @OvokInSpaceHigh = 记录的扰动以与行星环相似的模式共振。
+        @OvokInSpace = 记录的无线电干扰仅是背景中的环。
+
+        @UrlumInSpace = 记录了与太阳系中其他天体截然不同的极其复杂的无线电签名。
+        @UrlumInSpace = 无线电签名确认Urlum具有非常强大和活跃的磁场，这对其对太阳等离子体的影响给出了证据。
+
+        @WalInSpaceLow = 仪器检测到了月球与Urlum磁层相互作用时的无线电干扰。
+        @WalInSpaceHigh = 检测到了由Wal的子卫星Tal运动搅动的带电粒子漩涡。
+
+        @TalInSpace = 无线电干扰与金属物质干扰Wal磁场一致。
+        @TalInSpace = 等离子体相互作用似乎与Tal围绕其母卫星的轨道同步。
+
+        @PriaxInSpaceHigh = 在此高度检测到了非常小的波动，但似乎不是由Priax引起的。
+        @PriaxInSpaceLow = 再次进行无线电-等离子体科学探测仍然仅检测到来自Urlum的背景辐射。
+
+        @PoltaInSpaceHigh = 仪器检测到了Polta-Priax轨道共振的效果。
+        @PoltaInSpaceLow = 变化的测量表明Polta可能在其地壳下含有某些液体，或者地质活动活跃。
+
+        @NeidonInSpace = Neidon在较高磁纬度，特别是其北极附近，有一些强烈的无线电-等离子体读数。
+        @NeidonInSpace = 对受影响太阳等离子体的测量与磁场中非偶极分量的瞬态效应一致。
+
+        @ThatmoInSpaceHigh = 检测到了一些干扰，可能是Thatmo上层大气中正在进行的电离过程。
+        @ThatmoInSpaceLow = 无线电天线检测到了Neidon背景无线电发射的可测量扰动，当月球经过时。
+    }
+    //@RESULTS:NEEDS[DmagicOrbitalScience]{}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_orbitalScope]]:AFTER[CoatlAerospace]
+{
+    @title = 轨道图像拍摄
+    @RESULTS
+    {
+        @default = 表面图像以马赛克形式拍摄，用于数字拼接
+        @default = 飞行器飞过时拍摄了一系列表面图像
+        @default = KSC科学家们迫不及待地开始审查图片中的所有表面特征
+
+        @SunInSpace = 图像完全被白色洗白
+        @SunInSpace = 图像在实习生查看后归档，他尖叫道“我的眼睛！”
+
+        @MohoInSpace = 表面上的各种颜色表明Moho可能曾经有过火山活动
+        @MohoInSpaceLow = 表面特征暗示了一个有趣的过去，但现在只留下一个被太阳粒子严重侵蚀的荒凉之地
+        @MohoInSpaceHigh = 开始从Moho接收望远镜图像
+        @MohoInSpaceLowNorthernSinkhole = 这个巨大的地形凹陷中可见大量表面侵蚀
+        @MohoInSpaceLowNorthPole = 检测到一个非常尖锐且危险的深凹陷，科学家们讨论未来对该区域的探测任务
+
+        @EveInSpace = 表面上有许多引人注目的紫色特征和大气
+        @EveInSpaceLowPoles = 晶体物质覆盖表面，形成有趣的图案，被表面风侵蚀
+        @EveInSpaceLowHighlands = 紫色沙丘形成的高大沙丘在大片平坦地形上温柔地断裂
+        @EveInSpaceLowPeaks = 山脉挑战着重力，高高耸立在海平面上
+        @EveInSpaceLowExplodiumSea = 这个引人注目的液态体的反照率引发了对其化学成分的讨论
+        @EveInSpaceLow = 可见多种地形，从山脉到大型紫色湖泊
+        @EveInSpaceHigh = Eve厚厚的紫色大气使得从这个距离几乎看不到表面特征
+
+        @GillyInSpace = 望远镜缓慢转向以避免吓到小卫星
+        @GillyInSpaceLow = 表面上可见非常小的岩石，几乎被微弱的重力保持在那里
+        @GillyInSpaceHigh = Gilly的表面上没有明显的撞击坑。这颗卫星似乎无法将任何东西拉向它
+        @GillyInSpaceLowHighlands = Gilly的较高区域形成非常不平坦的地形
+
+        @KerbinInSpace = Kerbin！我们的家园！
+        @KerbinInSpaceLowWater = Kerbin的大洋从轨道上看显得非常湿润
+        @KerbinInSpaceLowDeserts = 发现沙子上有风雕刻的非常有趣的图案，并沉积在较低海拔区域
+        @KerbinInSpaceLowMountains = Kerbin的山脊非常高，从太空清晰可见
+        @KerbinInSpaceLowShores = Kerbin海岸被海洋冲刷，被侵蚀和偶尔的游客打断
+        @KerbinInSpaceLowGrasslands = 许多树木和植物覆盖着茂密的草原
+        @KerbinInSpaceLow = KSC收集图像以预测下次发射的天气
+        @KerbinInSpaceLow = 拍摄云层图案并发送给气象办公室
+        @KerbinInSpaceHigh = 蓝色阳光散射使大气呈现出蓝色调
+
+        @MunInSpace = Mun表面布满了撞击坑
+        @MunInSpace = Mun表面坑坑洼洼且地形有趣
+        @MunInSpaceLowTwinCraters = 这两个撞击坑是否同时发生？
+        @MunInSpaceLowFarsideCrater = Mun的背面也有大型撞击坑！
+        @MunInSpaceLowMidlands = 可见非常不平坦的地形，有时被侵蚀成光滑的沙丘
+        @MunInSpaceLowHighlands = Mun的高地比低地高得多。看起来很难攀登！
+        @MunInSpaceLowCanyons = 撞击坑和表面侵蚀似乎在表面形成了有趣的峡谷
+        @MunInSpaceLow = 更近距离观察，可见更多撞击坑特征。有些坑壁非常高，表明撞击非常强大
+        @MunInSpaceLow = 表面上可见大量有趣的岩石和尘土
+
+        @MinmusInSpace = 表面非常绿色，引发了对其与Kerbal DNA关联的猜测
+        @MinmusInSpaceLow = 大部分表面相当平坦，便于着陆
+        @MinmusInSpaceLow = 表面似乎覆盖着一种晶体状、美味的物质
+        @MinmusInSpaceLowPoles = 极端有非常高、平坦的台地状结构
+        @MinmusInSpaceLowLesserFlats = 这里的地形远不如中地有趣
+        @MinmusInSpaceLowGreatFlats = 大面积非常无聊的地形！
+        @MinmusInSpaceLowGreaterFlats = 广阔的非常无聊的地形！
+
+        @DunaInSpace = Duna表面呈现出非常红橙色、锈色的色调
+        @DunaInSpace = 明亮的白色冰盖与表面土壤的强色调形成鲜明对比
+        @DunaInSpaceLow = 表面上可见非常多的尘土，有时形成高大的沙丘
+        @DunaInSpaceLowPolarHighlands = 非常高的冰架高耸于冰盖之上
+        @DunaInSpaceLowPoles = 发现非常寒冷和滑溜的冰层
+        @DunaInSpaceLowPoles = 大量的水和二氧化碳似乎在Duna极地冻结
+        @DunaInSpaceLowCraters = 表面上的许多撞击坑至少部分被风和侵蚀填满沙子
+        @DunaInSpaceLowMidlandSea = 这个非常大的凹陷看起来覆盖了行星的一半，似乎是古代湖泊床
+        @DunaInSpaceLowMidlandCanyon = 图像分析表明，峡谷可能是由很久以前流动的水部分雕刻而成
+        @DunaInSpaceLowEasternCanyon = 图像分析表明，峡谷可能是由很久以前流动的水部分雕刻而成
+        @DunaInSpaceLowWesternCanyon = 图像分析表明，峡谷可能是由很久以前流动的水部分雕刻而成
+
+        @IkeInSpace = 为分析拍摄表面图像马赛克
+        @IkeInSpaceLow = 表面的更详细分析显示神秘的撞击坑缺乏
+        @IkeInSpaceLow = 与Mun不同，Ike似乎几乎没有撞击坑
+        @IkeInSpaceHigh = Ike表面非常灰暗且多岩石
+        @IkeInSpaceLowLowlands = 低地周围有一些陡峭的斜坡。大块岩石似乎滚下山并停留在这里
+
+        @DresInSpace = 望远镜拍摄了灰色且不平坦的表面
+        @DresInSpace = 冰块斑块打破了类似于Mun的表面
+        @DresInSpaceLow = Dres的表面非常类似于Mun
+        @DresInSpaceLowCanyons = 深峡谷边缘非常不规则，看起来难以导航
+
+        @JoolInSpaceLow = 云层顶部的特写显示了由带分离的非常有趣的组成
+        @JoolInSpaceLow = 某些照片中发现了一些伪像和干扰。看起来辐射影响了仪器
+        @JoolInSpaceHigh = 从轨道上看，Jool显得非常壮观
+
+        @LaytheInSpace = 像Kerbin一样，Laythe的大气呈现出蓝色调
+        @LaytheInSpace = Laythe看起来像一个美丽的、极其咸的、冻结的度假胜地。紧邻一个捕获辐射的气态巨行星
+        @LaytheInSpaceHigh = Laythe看起来完全被海洋覆盖。不，等等，是陆地！
+        @LaytheInSpaceLow = 下方发现许多岛屿形成群岛
+        @LaytheInSpaceLowTheSagenSea = 大部分Laythe被这个巨大的咸海覆盖
+        @LaytheInSpaceLowDeGrasseSea = 哇，我们这里有一个超赞的海！
+
+        @VallInSpace = Vall表面非常不平坦，有频繁的高度变化
+        @VallInSpace = 冲击坑被严重侵蚀，可能暗示某种地质活动
+        @VallInSpaceLow = Vall的冰表面几乎没有岩石和其他特征
+        @VallInSpaceLow = 图像分析揭示冰地表最近被重新覆盖，暗示可能存在火山活动
+
+        @TyloInSpace = 表面几乎没有撞击坑。只发现少数大型撞击坑
+        @TyloInSpace = Tylo看起来像一个岩石覆盖的Mun，但撞击坑较少
+        @TyloInSpaceLow = 图像的近距离检查发现表面土壤中散落着一些冰颗粒
+        @TyloInSpaceLow = 月球较高的反照率被认为是由表面的冰颗粒造成的
+        @TyloInSpaceLowMara = 暗色玄武岩覆盖这些区域，暗示Tylo可能曾经有过火山活动
+
+        @PolInSpaceLow = 表面地形非常不规则
+        @PolInSpaceLow = 表面细节图像显示散落在表面的尖刺，让地质学家们要求取样
+        @PolInSpace = 图像显示非常明亮且多样的表面颜色，可能是撞击或火山活动暴露的硫酸盐或矿物质
+
+        @BopInSpace = Bop的图像显示一个非常不规则且多岩石的天体，可能是被捕获的小行星
+        @BopInSpaceLow = 棕色表面非常岩石，几乎没有散落的材料
+        @BopInSpaceLowPeaks = Bop的山峰高耸在海平面上
+
+        @EelooInSpace = 图片显示表面覆盖着冰，有裂缝和显示下方棕色岩石的陨石坑
+        @EelooInSpaceLow = 冰的最上层看起来非常光滑且滑溜
+        @EelooInSpaceLowFragipan = 图像显示冰中有裂缝，下方的岩石表面可见
+        @EelooInSpaceLowIceCanyons = 这些被冰覆盖的峡谷有时看起来非常深。可见一些岩石表面的补丁
+        @EelooInSpaceLowMidlands = 表面的一些区域形成了冰丘，暗示某种侵蚀形式
+
+        //OPM
+
+        @SarnusInSpace = 望远镜捕捉到了Sarnus的一些令人惊叹的图像
+        @SarnusInSpace = 拍摄了壮观的环系统，揭示了地面望远镜无法看到的细节
+        @SarnusInSpaceLow = 仪器捕捉到了大气带和扰动的更多细节
+        @SarnusInSpaceLow = 环的特写图像显示了前后护卫卫星之间的冰物质波
+        @SarnusInSpaceHigh = 从这些图像中可以清楚地分辨出不同的环
+
+        @TektoInSpaceHigh = 该卫星大部分被一层柔和的绿色雾气遮挡，隐藏了表面特征
+        @TektoInSpaceHigh = 大气的柔和光芒偶尔被似乎彩色极光的中断
+        @TektoInSpaceLow = 图像显示云层以不同的速度和高度移动
+        @TektoInSpaceLow = 图像中可见一些表面特征。一名科学家在一张较暗的图像上写下了“sogal”
+        @TektoInSpaceLow = 表面被较暗的补丁分割，肯定会引发对其成分的大量辩论和猜测
+        @TektoInSpaceLowMedikohlLake = 图像显示下方有反射表面，暗示存在大型液态体
+        @TektoInSpaceLowAntenorLake = 图像显示下方有反射表面，湖泊似乎确实充满了某种液体
+        @TektoInSpaceLowVexxusLake = 图像显示下方有反射表面，暗示存在大型液态体
+        @TektoInSpaceLowSiliskoSea = 图像显示下方有反射表面，确认存在某种液体
+        @TektoInSpaceLowTwinLakes = 图像显示下方有反射表面，湖泊似乎确实充满了某种液体
+
+        @SlateInSpace = 望远镜传输了Slate黄色-棕色表面的图像马赛克
+        @SlateInSpaceHigh = 图像显示了似乎不是由撞击坑造成的大型凹陷，可能是古代湖泊床
+        @SlateInSpaceHigh = 图像显示一个非常干燥且多岩石的卫星
+        @SlateInSpaceLow = 影响坑的数量和年龄表明该卫星最近失去了大气层
+        @SlateInSpaceLow = 表面材料似乎最近被火山活动或撞击抛射物沉积
+        @SlateInSpaceLowMountNehelennia = 根据地形和表面材料，这很可能是活跃的火山
+        @SlateInSpaceLowYahelMountains = Slate发现有趣的山脉；进一步证据表明过去地质活动非常活跃
+        @SlateInSpaceLowSomborMountains = Slate发现有趣的山脉；进一步证据表明过去地质活动非常活跃
+        @SlateInSpaceLowNorthernSea = 图像显示一个可能曾经容纳过碳氢化合物海的凹陷
+        @SlateInSpaceLowSouthernSea = 图像显示一个可能曾经容纳过碳氢化合物海的凹陷
+        @SlateInSpaceLowEudaeBay = 图像显示一个可能曾经容纳过碳氢化合物海的凹陷
+        @SlateInSpaceLowRobauBay = 图像显示一个可能曾经容纳过碳氢化合物海的凹陷
+
+        @HaleInSpaceHigh = 图像显示该卫星在轨道上穿过环时吸收和清除材料，生成环粒子的缺口
+        @HaleInSpaceHigh = 环上的阴影揭示该卫星通过时会生成小的材料波，推动和拉动环材料上下环平面
+        @HaleInSpaceLow = 图像显示高度不规则的表面，应该会生成非常有趣的地形图
+        @HaleInSpaceLow = 该卫星大部分非常明亮。一些暗补丁可能是冰层之间的碳质岩石
+        @HaleInSpaceLowMacula = 望远镜图像非常暗的岩石区域需要进一步检查
+        @HaleInSpaceLowAmariusRegion = 图片显示下方有明亮的冰层，陨石坑覆盖着雪状材料
+
+        @OvokInSpaceHigh = 科学团队最初怀疑是在开玩笑，但事实证明Ovok确实非常光滑
+        @OvokInSpaceHigh = Ovok图像揭示该卫星非常光滑且美味地呈蛋形
+        @OvokInSpaceLow = 表面图像显示了意外缺乏撞击坑
+        @OvokInSpaceLowMaculaOblongata = 这是该卫星光滑表面最有趣的地形
+        @OvokInSpaceLowTasiRegion = 这无疑是太阳系最大的冰场
+
+        @UrlumInSpace = 望远镜发回了Urlum柔和蓝色大气的美丽图像
+        @UrlumInSpaceLow = Urlum大气中几乎可见较亮的物质带
+        @UrlumInSpaceHigh = 可见围绕气态巨人的非常微弱的环系统
+        @UrlumInSpaceHigh = 当飞船接近Urlum时，大气中的微弱带开始变得可见
+
+        @WalInSpace = Wal的图像显示了丰富且多样的表面
+        @WalInSpace = 望远镜发回了这个美味卫星的图像。可爱的Tal也被捕捉到在Wal上移动
+        @WalInSpaceHigh = 图像显示Tal和Wal有趣的轨道舞蹈
+        @WalInSpaceLow = 多层地壳暴露在强大撞击和潮汐力下的多色地形看起来非常多样
+        @WalInSpaceLow = 卫星的赤道隆起显然与它的次卫星Tal的潮汐拉扯有关
+        @WalInSpaceLow = Wal表面材料似乎是岩石和金属的混合物，带有一些硫酸盐沉积
+
+        @TalInSpace = 接收到的图像显示Tal光滑的表面
+        @TalInSpace = Tal和Wal表面的比较确实显示了惊人的相似性，进一步支持了Tal是由很久以前Wal上的强大撞击产生的理论
+        @TalInSpaceLow = Tal的表面出乎意料地光滑。必须有某种过程不断重新覆盖它
+
+        @PriaxInSpace = Priax看起来真的像一个小行星
+        @PriaxInSpaceLow = Priax表面显示出持续撞击的迹象，一些撞击坑看起来非常古老
+        @PriaxInSpaceLowLeadingCraters = 该区域似乎比Priax上的其他区域受到更多撞击
+        @PriaxInSpaceLowTrailingCraters = 与它的前侧相比，该区域似乎缺乏撞击坑
+        @PriaxInSpaceLowBadieRegion = 该区域似乎是被Polta偏转的微陨石的目标
+
+        @PoltaInSpace = 我们确定不是在看Minmus吗？
+        @PoltaInSpace = Polta看起来就像Minmus。任务控制悄悄重新检查了跟踪站的数据
+        @PoltaInSpaceHigh = Polta显示其复杂的灰色-绿色表面，带有类似沙漠沙丘的旋涡
+        @PoltaInSpaceLow = 图像显示非常复杂且独特的地形，可能是由撞击、潮汐力和水蒸气间歇泉的组合形成的
+
+        @NeidonInSpace = Neidon的精彩图像肯定会成为社交媒体上的热门话题
+        @NeidonInSpaceLow = Neidon的云和气带比其他气态巨行星更加引人注击
+        @NeidonInSpaceLow = 对图像序列的仔细分析使Neidon的云被测量出移动速度高达500 m/s！！！
+        @NeidonInSpaceHigh = Neidon的紫色色调可能暗示与Eve的某些化学相似性
+        @NeidonInSpaceHigh = 极地附近可见一些剧烈风暴。尚不确定是什么导致它们，但揭示了一个丰富的天气系统
+
+        @ThatmoInSpaceHigh = 望远镜曝光度必须大幅降低以防止表面图像被洗白
+        @ThatmoInSpaceHigh = 一个非常明亮的雪球状世界正在进入视野，地平线上的微弱雾气提供了该卫星大气存在的明确证据
+        @ThatmoInSpaceLow = 大片明亮的冻结荒原延伸至Neidon最大卫星的长度
+        @ThatmoInSpaceLow = 通过一些巧妙的调整，望远镜成功捕捉到一些向Thatmo大气喷射物质的间歇泉
+        @ThatmoInSpace = 哇！Thatmo真的很亮！
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_soilScoop]]:AFTER[CoatlAerospace]
+{
+    @title = 土壤采集
+    @RESULTS
+    {
+        @default = 机械臂暴露了表面以下的一些物质
+        @default = 刮板刮除了表层以供分析
+        @default = 拍摄了暴露的风化层图像
+
+        @MohoSrfLanded = 这是刮板开始熔化
+        @MohoSrfLanded = KSC对机械臂还没有熔化感到更兴奋
+        @MohoSrfLandedNorthPole = 刮板臂很难伸入Moho洞
+
+        @EveSrfLanded = 土壤成分适合采样，假设你能起飞并带回样本
+        @EveSrfSplashed = 噗通一声，采集臂落在了海里。
+        @EveSrfSplashed = 机械臂溅入海洋，水开始冒泡和蒸发
+
+        @GillySrfLanded = 刮板扰动了一小部分物质，这些物质迅速以逃逸速度飘走
+
+        @KerbinSrf = 任务控制中心认为下次只需派实习生带着铲子来会更便宜
+        @KerbinSrfSplashed = 噗通一声，采集臂落在了水里。
+        @KerbinSrfSplashed = 工程团队短暂考虑过用刮板作为船桨
+        @KerbinSrfLandedKSC = 伸展的机械臂绊倒了一个博士的助手
+        @KerbinSrfLandedKSC = KSC警察因扰乱航天中心周围的景观和建筑物而对任务控制中心处以罚款
+        @KerbinSrfLandedDeserts = 看起来下面有更多的沙子
+        @KerbinSrfLandedShores = 哦，看，有一些闪亮的季节性贝壳露出来了！
+        @KerbinSrfLandedGrasslands = 机械臂差点被草缠住
+        @KerbinSrfLandedMountains = 刮板在岩石表面上划痕
+        @KerbinSrfLandedTundra = 下面有厚厚的冰层覆盖着细雪
+        @KerbinSrfLandedRunway = 机械臂挖到了一些撕裂的轮胎碎片和一种奇怪的绿色物质
+
+        @MunSrfLanded = Mun风化层布满灰尘，散落着较大的颗粒
+        @MunSrfLanded = 最上面的尘土层有几厘米深，可能对行走和驾驶构成一定困难
+
+        @MinmusSrfLanded = 任务控制中心意识到这只是一个非常昂贵的冰淇淋勺
+        @MinmusSrfLanded = 科学家们研究了暴露物质的图像后得出结论：青柠雪芭
+
+        @DunaSrfLanded = 表层是非常细腻的灰尘
+        @DunaSrfLanded = 刮板暴露了几厘米以下较暗的灰尘
+        @DunaSrfLanded = 暴露了一些明亮的物质，可能是冰？
+
+        @IkeSrfLanded = Ike土壤较少灰尘，更多岩石
+        @IkeSrfLanded = 刮板刮擦岩石材料，需要强力钻头才能采集到表面以下的样本
+
+        @DresSrfLanded = Dres的风化层与Mun的风化层有惊人的相似之处
+
+        @JoolSrfLanded = 工程团队因其开发的系统能够从气态巨行星表面采集物质而获得最高奖项！
+
+        @LaytheSrfLanded = 土壤层具有类似于Kerbin的特性
+        @LaytheSrfLanded = 鉴于Laythe上的水量，能与一些土壤互动实际上是相当罕见的
+
+        //以下四个Jool卫星的科学报告不存在，由译者通过AI补充
+        VallSrfLanded = Vall的表面覆盖着厚厚的冰层，机械臂在坚硬的冰面上留下明显的划痕。
+        VallSrfLanded = 尽管温度极低，但探测器成功采集了少量冰样，为研究Jool系统的形成提供了宝贵数据。
+
+        TyloSrfLanded = Tylo的表面布满了陨石坑和山脉，机械臂在崎岖的地表上操作困难。
+        TyloSrfLanded = 探测器成功采集了岩石样本，这些样本将帮助科学家更好地理解Jool系统的地质历史。
+
+        BopSrfLanded = Bop的表面充满了奇特的地貌，包括峡谷和丘陵，机械臂在这里发现了不同寻常的矿物质。
+        BopSrfLanded = 尽管Bop的大气层极其稀薄，探测器仍成功采集了样本，揭示了这个小卫星的独特地质构成。
+
+        PolSrfLanded = Pol的表面像一面镜子，反射着强烈的阳光，机械臂在光滑的冰面上小心翼翼地操作。
+        PolSrfLanded = 探测器采集到了高度纯净的冰样，这些样本将有助于研究Jool系统的早期演化
+
+        @EeelooSrfLanded = 刮板发出的刮擦声确认这是一个冰冻的表面
+        @EeelooSrfLanded = 表面有细小的雪粒，但主要是大块的冰
+
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_IRspec]]:AFTER[CoatlAerospace]
+{
+    @title = 红外光谱测量
+    @RESULTS
+    {
+        @default = 您测量了仪器视野中的红外光谱
+        @default = 光谱仪进行了局部红外测量
+        @default = 检测到了不同级别的热辐射和反射
+
+        @SunInSpace = 记录了围绕Kerbol的红外数据
+        @SunInSpaceLow = 任务控制中心消息：“不要直接看太阳”
+        @SunInSpaceLow = 红外测量短暂超出范围，随后仪器进入安全模式以防止损坏
+        @SunInSpaceHigh = 部署日冕仪测量Kerbol的日冕，揭示了极高的温度
+
+        @MohoInSpace = Moho的热辐射被IR光谱仪成像
+        @MohoInSpaceLow = 表面红外吸收分析表明存在铁和其他金属
+        @MohoInSpaceLow = 在Moho的红外图像中，白天和夜晚的温差非常明显
+        @MohoInSpaceHigh = 面向Kerbol的一侧显得非常明亮且炎热
+        @MohoInSpaceHigh = 记录了红外水平。实验室实习生需要确定它们来自Moho还是Kerbol
+
+        @EveInSpace = 围绕Eve拍摄了红外图像
+        @EveInSpaceLow = Eve的大气吸收了大量的红外辐射
+        @EveInSpaceHigh = IR辐射计算表明大量红外辐射被困在云层之下
+        @EveInSpaceHigh = 红外图像揭示了一个与Kerbin截然不同的世界
+
+        @GillyInSpace = 该仪器从Gilly周围拍摄了红外图像
+        @GillyInSpaceLow = 光谱分析显示表面存在一些金属和矿石
+        @GillyInSpaceHigh = 热读数表明没有火山活动
+
+        @KerbinInSpace = 记录了围绕Kerbin的热辐射数据
+        @KerbinInSpaceLow = 应Sean's Cannery的要求，拍摄了农田的表面红外地图
+        @KerbinInSpaceLow = 表面附近有一个大的热峰值。哦，原来是KSC发射了一枚火箭！
+        @KerbinInSpaceLow = 光谱仪检测到海洋下方的一个非常奇怪的异常；在台风中间。任务控制中心将其标记为“红外十月”
+        @KerbinInSpaceHigh = 该仪器调整为拍摄当前云覆盖的红外地图
+        @KerbinInSpaceHigh = 注意到人口密集区周围的红外辐射，以帮助寻找其他星球上的生物活动
+        @KerbinInSpaceHigh = 红外图像穿透了Kerbin的云层，使不同的地面特征更加明显
+
+        @MunInSpace = 月球看起来很冷
+        @MunInSpaceLow = 较深的陨石坑足够冷，可以在阴影区域维持水冰
+        @MunInSpaceHigh = 陨石坑比高地要冷得多
+        @MunInSpaceHigh = 热成像使得识别不同的地形特征变得更加容易
+
+        @MinmusInSpace = 记录了表面的红外地图
+        @MinmusInSpaceLow = 红外数据显示Minmus非常冷
+        @MinmusInSpaceLow = 红外光谱分析完成：鳄梨酱（注：这里可能是一个玩笑或错误）
+        @MinmusInSpaceHigh = 高地似乎比低地更温暖
+        @MinmusInSpaceHigh = 不同的地形层次发出或反射不同量的红外光
+
+        @DunaInSpace = 拍摄了Duna的红外波长图像
+        @DunaInSpaceLow = 地质特征在红外图像中很容易辨认
+        @DunaInSpaceLow = 极地非常冷并含有水冰
+        @DunaInSpaceHigh = 红外数据显示Duna比理论预测的要冷得多
+        @DunaInSpaceHigh = 尽管其沙漠外观，Duna实际上相当冷
+
+        @IkeInSpace = IR光谱仪测量了热量吸收
+        @IkeInSpaceLow = 红外数据显示Ike表面存在金属和矿石
+        @IkeInSpaceHigh = Ike似乎有一个非常暗且不反光的岩石表面
+
+        @JoolInSpace = 虽然花费了一些时间，但最终完成了Jool的红外地图
+        @JoolInSpace = Jool的极光在这个波长下显得非常明亮
+        @JoolInSpaceLow = Jool的云层中含有许多高温挥发性化学物质
+        @JoolInSpaceHigh = Jool的云带和云带在不同的红外波长下清晰可见
+        @JoolInSpaceHigh = Jool释放的热量比它接收到的还要多，暗示可能存在内部热源
+
+        @LaytheInSpace = 控制台发出蜂鸣声，记录了Laythe的红外读数
+        @LaytheInSpace = 扫描表明极地不含冰
+        @LaytheInSpaceLow = 红外图像显示了许多小的岩石岛屿
+        @LaytheInSpaceLow = 分析表明大气主要由氮、甲烷、乙烷和乙炔组成
+        @LaytheInSpaceHigh = Laythe释放的热量比它接收到的还要多，类似于Jool
+
+        @VallInSpace = 对表面进行了红外读数
+        @VallInSpaceLow = 扫描显示Vall的表面是冰冻的
+        @VallInSpaceLow = 光谱分析显示月球上有水、氨和甲烷
+        @VallInSpaceHigh = 热成像显示地形非常不均匀。不建议着陆
+        @VallInSpaceHigh = 地形扫描捕捉到了可能是许多火山的影像。状态未知
+
+        @BopInSpace = 对Bop进行了红外扫描
+        @BopInSpaceLow = 扫描显示表面有类似触手的特征
+        @BopInSpaceHigh = 由于没有大气层，该卫星吸收了很多热量
+
+        @TyloInSpace = 控制台发出蜂鸣声，记录了扫描结果
+        @TyloInSpaceLow = 读数显示表面含有钴、镍和冰
+        @TyloInSpaceHigh = 扫描显示表面有冰
+        @TyloInSpaceHigh = 热。谁会想到？
+
+        @PolInSpace = IR控制台不断发出蜂鸣声。是不是坏了？
+        @PolInSpaceLow = 扫描设置为nelop。结果为阴性
+        @PolInSpaceHigh = 红外扫描显示地形不均匀
+
+        @EelooInSpace = Eeloo屈服于红外成像的力量
+        @EelooInSpace = 从高处收集了Eeloo表面的红外数据
+        @EelooInSpaceLow = 发现水冰构成了Eeloo冰冻表面的下层
+        @EelooInSpaceLow = 光谱仪检测到甲烷、一氧化碳和氮冰
+        @EelooInSpaceHigh = 表面高处的冰升华现象表明Eeloo可能曾经有过稀薄的大气层
+        @EelooInSpaceHigh = Eeloo的表面被冰覆盖！
+
+        // 外行星模组
+
+        @SarnusInSpace = 从Sarnus周围捕获了红外光谱图像
+        @SarnusInSpace = 图像显示大气中有明显的条带和云层，这些特征通过标准望远镜不易察觉
+        @SarnusInSpaceLow = 大气图像显示条带以不同的速度移动
+        @SarnusInSpaceLow = 更接近的环图像证明外环比内环更反光且更冰
+        @SarnusInSpaceHigh = Sarnus释放的热量约为其从Kerbol接收到的2.5倍，大部分热量集中在南极
+        @SarnusInSpaceHigh = 发现一个尘埃环轨道远高于其他环，几乎看不见！
+
+        @TektoInSpaceLow = 大气高层的许多云更容易用这种红外波长检测到
+        @TektoInSpaceLow = 低角度红外图像捕捉到表面的镜面反射；确认表面存在液体
+        @TektoInSpaceHigh = 仪器的较长波长穿透朦胧的大气层，成像出非常多样化的表面特征
+        @TektoInSpaceHigh = 表面上可以看到亮区和暗区。科学团队希望将图像与高度图结合，以获得更完整的表面分析
+
+        @SlateInSpaceHigh = Slate的表面主要由冷却的岩石构成，没有冰沉积物
+        @SlateInSpaceHigh = 该卫星有丰富的地质历史证据，包括一些可能活跃的火山
+        @SlateInSpaceLow = 在撞击坑附近发现了少量冰，可能是最近由撞击带来的
+        @SlateInSpaceLow = Slate表面覆盖着大量的火山岩和其他材料，显示出丰富的地质历史
+        @SlateInSpaceLow = 仪器检测到大量的玄武岩沉积物
+
+        @HaleInSpace = 该仪器从Hale周围拍摄了红外图像
+        @HaleInSpaceHigh = 热成像使得识别不同的地形特征变得更加容易
+        @HaleInSpacelow = 热成像确认了大量水冰的存在
+
+        @OvokInSpaceHigh = Ovok的整个表面都非常均匀地寒冷
+        @OvokInSpaceLow = 热图像显示表面不同区域之间没有重大波动，表明它们具有相同的成分
+        @OvokInSpace = Ovok的红外图像显示其表面完全被冰覆盖
+
+        @UrlumInSpaceLow = Urlum释放的热量比预期的要少得多
+        @UrlumInSpaceLow = 红外成像检测到由甲烷组成的云带漂浮在碳氢化合物烟雾和氦冰泥混合物中
+        @UrlumInSpaceHigh = 使用红外波长，Urlum的条带和大气特征非常明亮可见
+        @UrlumInSpaceHigh = 分析表明大气由氢、氦和甲烷组成。后者解释了这颗行星的颜色
+        @UrlumInSpaceHigh = 使用红外成像，Urlum的环更容易成像，似乎由岩石碳质材料构成
+
+        @WalInSpace = 记录了表面的红外地图
+        @WalInSpaceHigh = 尽管非常冷，但该卫星表现出一些内部加热的迹象，暗示可能存在地质活动
+        @WalInSpaceLow = 红外光谱显示一个由不同岩石类型和一些暴露金属以及冰袋组成的多样化表面
+
+        @TalInSpace = 控制台发出蜂鸣声，红外图像从TalInSpace流下来
+        @TalInSpace = 这个小卫星高度反光，表明表面有大量的冰
+        @TalInSpaceLow = 进一步的表面分析显示冰和金属的混合
+        @TalInSpaceHigh = Tal记录到一些内部加热，这可能是由于Wal的潮汐效应引起的
+
+        @PriaxInSpace = Priax的红外足迹与其他太阳系小行星一致
+        @PriaxInSpace = 图像显示该卫星非常岩石，没有任何特别有趣的东西出现在这个波长上
+        @PriaxInSpaceLow = 仔细分析排除了任何显著的冰沉积物
+
+        @PoltaInSpace = Polta的红外图像显示了一个非常多样化的表面。科学团队开始计划样本采集
+        @PoltaInSpace = 尽管与Minmus相似，但Polta的红外足迹更为独特，显示出一些活跃的地质活动
+        @PoltaInSpaceHigh = 红外测量显示内部加热的一些迹象。潮汐力可能正在加热其内部
+        @PoltaInSpaceLow = 图像捕捉到了低温火山的特征
+        @PoltaInSpaceLow = Polta含有大量的冰和岩石，化学成分丰富。科学家认为其中可能存在一些氯
+
+        @NeidonInSpaceLow = 热辐射显示了一个由不同速度和成分的物质带驱动的非常动态的天气系统
+        @NeidonInSpaceLow = 红外图像表明存在一个由氨、甲烷、碘和水蒸气组成的深层大气层
+        @NeidonInSpaceLow = Neidon的上层云似乎含有大量的二氧化碳和一氧化碳
+        @NeidonInSpaceHigh = Neidon产生的热足迹比预期的要高。解释了其非常活跃的天气系统
+        @NeidonInSpaceHigh = Neidon的南半球比北半球要暖得多。这形成了一个系统，其中甲烷气体在接近南极时变暖并升至更高海拔
+
+        @ThatmoInSpaceHigh = 到处都是冰，但仪器确实检测到了一些可能是活跃喷泉和低温火山的较温暖区域
+        @ThatmoInSpaceHigh = 低角度图像显示大气比表面要暖得多，因为它似乎在吸收太阳辐射
+        @ThatmoInSpaceLow = 红外成像仪检测到了明显的温暖、地质活跃区域
+        @ThatmoInSpaceLow = 光谱分析使科学团队得出结论，Thatmo的表面和大气中存在大量的二氧化碳和氮气
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_ionElec]]:AFTER[CoatlAerospace]
+{
+    @title = 离子化静电分析
+    @RESULTS
+    {
+        @default = 您测量大气的电学性质，寻找被电离的原子和分子
+        @default = 仪器在大气中搜索电离粒子
+        @default = 记录电离和静电数据
+
+        @SunInSpace = 你记录了Kerbol发出的大量带电粒子
+        @SunFlyingHigh = 这就是电路烧毁的样子
+        @SunInSpaceLow = 在靠近Kerbol的地方检测到非常高水平的带电粒子
+        @SunInSpaceLow = 高水平的电磁干扰迫使实验进入安全模式以防止损坏
+        @SunInSpaceHigh = 检测到带电粒子，可能是由太阳风携带的太阳等离子体带来的
+        @SunInSpaceHigh = 粒子数据分析表明Kerbol的喷发对于大气电离是必要的
+
+        @MohoInSpace = 记录了来自Moho周围的带电粒子测量
+        @MohoInSpaceLow = 尽管未检测到大气电离，但有迹象显示带电粒子被太阳风从表面吹走
+        @MohoInSpaceLow = 收集的数据揭示了缺乏通常存在于有大气层行星中的带电粒子
+        @MohoInSpaceHigh = 此处检测到的唯一带电粒子似乎来自Kerbol
+
+        @EveFlyingHigh = 突发的静电读数峰值暗示Eve上可能存在闪电现象
+        @EveInSpace = 记录了来自Eve周围的带电粒子测量
+        @EveInSpaceLow = 沿着Eve的磁鞘检测到高能粒子通量，进一步表明行星周围存在非常强的磁场
+        @EveInSpaceHigh = 沿着Eve的磁尾检测并绘制了带电粒子图
+
+        @GillyInSpace = 从Gilly周围进行了粒子电离测量
+        @GillyFlyingHigh = 进一步分析确认了缺乏大气层
+        @GillyInSpaceLow = 与太阳粒子无互动表明缺乏大气层
+        @GillyInspaceHigh = 传感器上没有有趣的东西
+
+        @KerbinFlyingHigh = 上层大气中的电离分子似乎将无线电波反射回地面
+        @KerbinFlyingHigh = 传感器检测到下方有电气风暴
+        @KerbinInSpace = 记录了来自Kerbin周围的带电粒子测量
+        @KerbinInSpaceLow = 电离粒子与电离层相互作用形成明亮的极光
+        @KerbinInSpaceLow = 在Kerbin的磁层内检测到了某种形式的能量带
+        @KerbinInSpaceHigh = 离子化水平随着远离行星的磁鞘而减少
+
+        @MunFlyingHigh = 没有科学数据就是好数据，对吧？
+        @MunInSpace = 你收集了Mun周围的带电粒子读数
+        @MunInSpaceLow = 尽管缺乏电活动，任务控制中心指出未来收集的任何Mun岩石样本应放在防静电袋中
+        @MunInSpaceHigh = 看起来一个大气层（Mun所缺少的）对于暴风雨天气是必需的
+
+        @MinmusFlyingHigh = 没有意义的数据。实习生们为不用梳理这些结果而欢呼
+        @MinmusInSpace = 从Minmus上方的空间收集了静电数据
+        @MinmusInSpaceLow = 静电分析完成：奇异果（注：这里可能是一个玩笑或错误）
+        @MinmusInSpaceHigh = 由于未检测到大气活动，任务控制中心取消了所有涉及气象学家的Minmus任务
+        @MinmusInSpaceHigh = 一条非常微弱的带电粒子轨迹似乎跟随Minmus
+
+        @DunaFlyingHigh = 虽然微弱，但Duna的大气显然能够进行静电互动
+        @DunaInSpace = 记录了Duna系统的带电粒子基本测量
+        @DunaInSpaceLow = 测量显示当太阳粒子与下层大气某些区域互动时产生极光
+        @DunaInSpaceHigh = 在薄的Dunan大气低海拔处微弱地检测到带电粒子
+
+        @IkeFlyingHigh = 没有大气数据报告，但从表面检测到了微弱的电信号
+        @IkeInSpace = 仪器记录了Ike附近的粒子水平
+        @IkeInSpaceLow = 静电结果显示Ike周围缺乏大气层
+        @IkeInSpaceHigh = Ike似乎对穿越Duna系统的太阳粒子有相当强烈的影响
+
+        @DresFlyingHigh = 静电数据不确定。任务控制中心提到关于招募宇航员电工的事
+        @DresInSpace = 记录了Dres周围的带电粒子数据
+        @DresInSpaceLow = 来自Kerbol的带电粒子似乎直接轰击表面，结果不确定
+        @DresInSpaceHigh = Dres上方没有数据表明缺乏大气层
+
+        @JoolFlyingHigh = 在大气深处，液态元素显示出像金属一样的导电性
+        @JoolInSpace = 记录了Jool系统的带电粒子数据
+        @JoolInSpaceLow = Jool被认为也有极光，因为检测到离子化粒子与高层大气互动
+        @JoolInSpaceLow = Jool的云层和带具有不同的静电水平，表明速度和高度不同
+        @JoolInSpaceHigh = Jool对太阳粒子有很大的偏转效应
+        @JoolInSpaceHigh = 巨大的气体巨星产生了许多奇特的静电结果，为实验室技术人员提供了数月的工作量
+
+        @LaytheFlyingHigh = 上层大气含有许多特别活跃的带电离子
+        @LaytheInSpace = 完成了来自Laythe上方的静电扫描
+        @LaytheInSpaceLow = 检测到电离粒子。它们是否生成极光尚不确定
+        @LaytheInSpaceHigh = 检测到带电粒子互动。确认Laythe有一个非常活跃的大气层
+
+        @VallFlyingHigh = ELIX没有检测到任何静电互动
+        @VallInSpace = ELIX扫描完成。实习生们欢呼！
+        @VallInSpaceLow = 科学家尝试不同的设置，最终宣布缺乏大气层
+        @VallInSpaceHigh = 初始扫描检测到带电粒子，但它们可能来自Jool
+
+        @TyloFlyingHigh = 在经过多个撞击坑时检测到非常微弱的信号
+        @TyloInSpace = 接收到ELIX数据扫描结果
+        @TyloInSpaceLow = Tylo也没有让Kerbol等离子体与其互动的大气层
+        @TyloInSpaceHigh = 看起来Tylo也没有大气层
+
+        @BopFlyingHigh = 来自表面下方有无法解释的电异常
+        @BopInSpace = 记录了静电数据。未检测到大气层
+        @BopInSpaceLow = ELIX检测到不规则的电脉冲。那些是质数吗？
+        @BopInSpaceHigh = 初始扫- *静电* 检测... *静电* -大气层
+
+        @PolFlyingHigh = 在P013-N站点上方检测到微弱信号
+        @PolInSpace = 接收到数据流。ELIX从Pol记录的数据
+        @PolInSpaceLow = 月球周围未检测到大气层
+        @PolInSpaceHigh = 检测到了几条由Jool引起的带电粒子“带”，但在接近Pol时它们消失了
+
+        @EelooFlyingHigh = ELIX设置为最高灵敏度，但什么也没有捡到
+        @EelooInSpace = 从Eeloo上方的空间收集了静电数据
+        @EelooInSpaceLow = Eeloo似乎没有任何静电电荷
+        @EelooInSpaceLow = 太阳风是否与飞船排出的推进剂反应？
+        @EelooInSpaceHigh = 检测到了非常微弱的信号，但似乎不是来自Eeloo
+
+        // OPM
+
+        @SarnusInSpace = 收到了来自Sarnus周围的静电数据
+        @SarnusInSpaceLow = 检测到了非常强大的闪电放电，比家里的闪电强几千倍！
+        @SarnusInSpaceLow = 静电测量表明存在高度导电的金属层
+        @SarnusInSpaceHigh = 强烈的电气风暴似乎存在于大气中
+        @SarnusInSpaceHigh = 捕获的粒子似乎聚集在两极附近，应该会产生明亮的极光
+
+        @TektoFlyingHigh = 仪器记录了表面摩擦电效应的证据，意味着Tekto的一些沙子可以静电充电
+        @TektoInSpaceLow = 检测到的电离粒子团簇可能表明大气中有极光的存在
+        @TektoInSpaceHigh = 仪器登记了一些可能是由Sarnus磁层引起的互动活动
+
+        @SlateInSpaceHigh = 没有科学数据就是好数据，对吧？
+        @SlateInSpaceHigh = 传感器上没有有趣的东西
+        @SlateInSpaceLow = ELIX扫描完成。实习生们欢呼！然后因未能找到大气层而全部被解雇
+        @SlateInSpaceLow = 静电结果确认缺乏大气层
+
+        @HaleInSpaceHigh = 没有科学数据就是好数据，对吧？
+        @HaleInSpaceHigh = Hale上方没有数据表明缺乏大气层
+        @HaleInSpaceLow = 静电结果确认缺乏大气层
+
+        @OvokInSpaceHigh = 传感器上没有有趣的东西
+        @OvokInSpaceLow = 科学家尝试不同的设置，最终宣布缺乏大气层
+
+        @UrlumInSpace = 记录了围绕Urlum的带电粒子数据
+        @UrlumInSpaceLow = 带电粒子数据显示Urlum磁场的南极大范围内的活动更多
+        @UrlumInSpaceLow = Urlum的云层和带具有不同的静电水平，表明速度和高度不同
+        @UrlumInSpaceHigh = 行星展示了与太阳等离子体有趣的互动，包括一些局部活动
+
+        @WalInSpaceHigh = 仪器记录确认缺乏大气电离
+        @WalInSpaceHigh = Wal看起来完全没有大气层
+        @WalInSpaceLow = 背景读数可能表明Wal的表面存在一些导电、金属材料
+
+        @TalInSpaceHigh = 仪器未检测到月球周围有任何大气层
+        @TalInSpaceLow = 仪器数据显示月球上可能存在非常导电的金属
+        @TalInSpace = 尽管未检测到大气层，Tal有一些有趣的导电性读数
+
+        @PriaxInSpaceHigh = Priax轨道的影响可以在Urlum的上层大气中检测到
+        @PriaxInSpaceLow = Priax内部可能存在一些导电金属，或者只是来自Urlum的尖峰测量。难以判断
+
+        @PoltaInSpaceHigh = 仪器检测到月球喷射出一些粒子的迹象。这可能是低温火山吗？
+        @PoltaInSpaceLow = Polta似乎缺乏静电电荷和大气层
+
+        @NeidonInSpace = Neidon有一个非常独特的静电特征，可能是由其独特的大气化学引起的
+        @NeidonInSpaceHigh = 测量显示大气中存在强烈的静电场
+        @NeidonInSpaceLow = 仪器数据显示存在电导液体，通过对流流体运动形成磁发电机
+
+        @ThatmoInSpaceHigh = 发现在Thatmo的上层大气中有一些非常微弱的活动，但手头的过程未知
+        @ThatmoInSpaceLow = 静电实验继续检测到一些读数，表明Thatmo大气中正在发生静电活动，可能与从Thatmo间歇泉喷出的升华氮有关
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_UVspec]]:AFTER[CoatlAerospace]
+{
+    @title = 紫外线大气分析
+    @RESULTS
+    {
+        @default = 您拍摄了紫外线波长的图像
+        @default = 拍摄了一系列紫外线图像
+        @default = 紫外光谱仪收集数据，以完成大气层调查
+
+        @SunInSpace = 由于强烈的辐射、热量和电磁干扰，LUV勉强在这个距离Kerbol的地方获得了一些读数。我们被告知保修已经失效
+        @SunInSpaceLow = 紫外测量短暂地超出了量程，然后仪器进入安全模式以防止损坏
+        @SunInSpaceLow = 尽管检测到难以置信高水平的紫外线辐射，任务控制中心拒绝将其重命名为“超-暴力”辐射
+        @SunInSpaceHigh = 检测到来自Kerbol的高紫外线辐射
+        @SunInSpaceHigh = 您想知道工程师是否给飞船涂了足够的防晒霜
+        @SunInSpaceHigh = LUV拍摄了Kerbol的日冕图像
+
+        @MohoInSpace = 拍摄了来自Moho周围的紫外线图像
+        @MohoInSpaceLow = 紫外反射表明极地附近的深陨石坑中可能存在冰
+        @MohoInSpaceHigh = 未检测到Moho周围有大气层
+        @MohoInSpaceHigh = 这么靠近Kerbol，紫外线辐射非常显著
+
+        @EveInSpace = 光谱仪开始对Eve进行大气层调查
+        @EveInSpaceLow = 在极地上方的紫外光谱中检测到了黑暗、神秘的斑块
+        @EveInSpaceLow = 发现云层中的某些点吸收的紫外线比其他地方更多
+        @EveInSpaceHigh = Eve的大气层被发现非常厚且反射性强
+        @EveInSpaceHigh = Eve的大气层似乎主要由二氧化碳和碘气体组成。是否为葡萄味尚不确定
+
+        @GillyInSpace = 测量了Gilly的紫外线反射
+        @GillyInSpaceLow = Gilly的表面看起来是岩石构成
+        @GillyInSpaceHigh = 这个小卫星周围未检测到大气层
+
+        @KerbinInSpaceLow = Kerbin的大气层吸收了大量的紫外线辐射
+        @KerbinInSpaceLow = 紫外指数很高。任务控制中心取消了今天的野餐
+        @KerbinInSpaceHigh = 在紫外线波长下绘制了Kerbin的云层图，寻找天气模式
+        @KerbinInSpaceHigh = Kerbin的有机化合物吸收了大量的紫外线辐射
+
+        @MunInSpace = 记录了Mun的紫外光谱
+        @MunInSpaceLow = 对水冰的位置和分布分析表明它们是由小行星或彗星撞击沉积的
+        @MunInSpaceLow = 深陨石坑内的反射率水平与已知的水冰相匹配
+        @MunInSpaceHigh = 一些陨石坑的表面分析显示从中心散发出的光线，这是由撞击后喷射出的物质羽流造成的
+
+        @MinmusInSpace = 记录了来自Minmus的紫外光谱仪读数
+        @MinmusInSpace = 紫外表面分析完成：薄荷
+        @MinmusInSpaceHigh = Minmus的表面反射了许多紫外线光，但少于预期
+
+        @DunaInSpace = 光谱仪拍摄了Duna的紫外线图像
+        @DunaInSpace = 反射率和吸收分析确认极冠含有大量的固态二氧化碳
+        @DunaInSpaceLow = 在极地附近检测到了少量的水冰
+        @DunaInSpaceLow = 大气数据表明稀薄的大气主要由二氧化碳组成
+        @DunaInSpaceLow = 在行星周围的某些区域检测到了Duna的极光
+        @DunaInSpaceHigh = Duna的大气似乎在行星后面微弱地蒸发
+
+        @IkeInSpace = 极地周围的微弱反射可能表明存在冰
+        @IkeInSpace = 生成了Ike的紫外地图
+        @IkeInSpaceLow = Ike的表面不怎么反光，由非常岩石的材料构成
+        @IkeInSpaceHigh = LUV的大气工具未在Ike周围检测到任何大气层
+
+        @DresInSpace = 从Dres周围获取了紫外线读数
+        @DresInSpace = 反射率分析显示其表面可能存在冰
+        @DresInSpaceLow = 表面散射分析揭示了表面上一个非常突出的峡谷
+        @DresInSpaceHigh = 紫外成像扫描确认Dres周围缺乏大气层
+        @DresInSpaceHigh = 在Dres附近检测到了其他反射物体。任务控制中心开始讨论是否要提高DEFCON等级
+
+        @JoolInSpace = 拍摄了大量图像以绘制Jool的紫外线排放图
+        @JoolInSpace = Jool的极光在紫外线波长下很容易看到
+        @JoolInSpaceLow = 大气分析显示低层雷暴云中含有水蒸气
+        @JoolInSpaceLow = 大气成分分析发现了氢气和氦气
+
+        @LaytheInSpace = LUV拍摄了Laythe的紫外照片
+        @LaytheInSpaceLow = 大气：检查，奇异岛屿：检查，“酷浪，伙计”：检查，KSC资助的度假：否决
+        @LaytheInSpaceLow = 紫外图像显示大片液态水体和遥远模糊的群岛
+        @LaytheInSpaceHigh = 紫外光谱研究验证了水的存在和有利于飞行的健康大气层
+        @LaytheInSpaceHigh = 反射率分析确认了大气层和大量的水
+
+        @VallInSpace = Vall的新紫外线图像准备好进行分析
+        @VallInSpaceLow = Vall有一个非常冰冻的表面，可能含有粘土硅酸盐
+        @VallInSpaceLow = LUV检测到一个微弱的水蒸气羽流，或者可能是小型低温火山
+        @VallInSpaceHigh = 未在Vall周围检测到大气层
+
+        @TyloInSpace = 未在Tylo周围检测到大气层
+        @TyloInSpaceLow = 陨石坑中检测到了冰袋。这些可能是由被Jool引力偏转的小行星和彗星撞击沉积的
+        @TyloInSpaceHigh = 高度反光的材料斑块很可能就是冰沉积物
+        @TyloInSpaceHigh = 仔细检查确认了Tylo周围缺乏大气层
+
+        @BopInSpace = Bop没有检测到大气层
+        @BopInSpaceLow = 表面图象表明它具有类似小行星的岩石和可能金属的构造
+        @BopInSpaceHigh = 探针遥测读数为“我恐怕不能那样做”
+
+        @PolInSpace = 进一步的紫外分析仍然没有找到大气层的痕迹
+        @PolInSpaceLow = 收到了紫外图象。来自Pol，带着爱
+        @PolInSpaceHigh = 表面上似乎几乎没有冰
+        @PolInSpaceHigh = 未检测到大气层。正在处理表面图象
+
+        @EelooInSpace = Eeloo的紫外线读数：已完成
+        @EelooInSpaceLow = 记录了紫外线水平。任务控制中心批准可以不用防晒霜
+        @EelooInSpaceLow = 表面上肯定有很多冰，可能是甲烷
+        @EelooInSpaceHigh = 他们应该派一位诗人来
+
+        // OPM
+
+        @SarnusInSpace = 从Sarnus捕获了紫外光谱图像
+        @SarnusInSpaceLow = 大气图像分析暗示最上层云由氨冰组成
+        @SarnusInSpaceLow = 云似乎在不同的高度形成，具有不同的元素组成
+        @SarnusInSpaceHigh = 图像确认环主要由大小不一的冰粒子组成
+        @SarnusInSpaceHigh = 外环的粒子似乎比内环粒子暴露更多的冰
+
+        @TektoInSpaceHigh = 对高层大气中光散射的分析表明主要是氮气
+        @TektoInSpaceLow = 发现Tekto的大气是一个非常密集的氮气与其他有机化合物的混合物
+        @TektoInSpaceLow = 检测到了大气中的有机化合物。氯的存在可能解释了它的绿色色调
+        @TektoInSpaceHigh = 透过朦胧看到的一些云位于更高的海拔，这表明它们有不同的化学组成
+        @TektoInSpaceHigh = 更详细的分析显示了一个非常密集的大气层。其上层的大部分与Kerbol的紫外线光相互作用
+
+        @SlateInSpace = 记录了来自Slate的紫外光谱仪读数
+        @SlateInSpaceHigh = 拍摄了Slate周围的紫外图像
+        @SlateInSpaceLow = 主要研究员对于缺乏大气层将使报告变得无聊感到沮丧
+        @SlateInSpaceLow = 表面反照率证实了岩石构造，几乎没有冰质材料
+
+        @HaleInSpace = 反射率分析显示表面有大量的冰
+        @HaleInSpaceHigh = 表面上确实有很多冰，可能与环相同
+        @HaleInSpaceLow = 黑暗、神秘的斑块打破了原本冰封的表面
+
+        @OvokInSpaceHigh = 未检测到大气层。正在处理表面图象
+        @OvokInSpaceHigh = 卫星表面到处都是高度反光的材料
+        @OvokInSpaceLow = 紫外光谱仪显示Ovok的不同特征之间没有显著差异
+        @OvokInSpaceLow = 紫外图像无法区分生物群落，如果有任何的话...
+
+        @UrlumInSpace = Urlum的新紫外线图像准备好进行分析！
+        @UrlumInSpaceLow = 紫外光谱显示云层中存在氨冰晶体
+        @UrlumInSpaceLow = 光谱仪检测到了变化的云成分
+        @UrlumInSpaceHigh = 在紫外波长下检测到了一些云成分数据，但在行星带之间几乎没有区别
+        @UrlumInSpaceHigh = 只有在对光谱仪设置进行了广泛调整之后，行星带才开始显示出一些差异
+
+        @WalInSpaceHigh = Wal看起来主要是一个岩石体，尽管有一些矿物或金属的迹象
+        @WalInSpaceHigh = 反射率分析显示Wal表面可能存在微小的冰袋
+        @WalInSpaceLow = 表面上有化学多样性的迹象
+        @WalInSpaceLow = 月球表面覆盖的冰很少，这在其远离Kerbol的距离上相当意外
+
+        @TalInSpace = 光谱仪拍摄了Tal的紫外线图像
+        @TalInSpace = 紫外光谱仪显示表面有大量的冰
+        @TalInSpace = 非常高的表面反照率确认了一个冰冻和平滑的表面
+
+        @PriaxInSpaceHigh = 图像显示了一个相对黑暗的小行星状卫星
+        @PriaxInSpaceLow = Priax在外太阳系中看起来像是一个岩石珍品，那里有许多冰质天体
+        @PriaxInSpace = Priax确实有显著的紫外线发射或反射。只是一块无聊的石头
+
+        @PoltaInSpaceHigh = 光谱仪正在接收高反照率测量值，这总是伴随着非常冰冻的表面而来
+        @PoltaInSpaceHigh = 地平线上方检测到了一些水蒸气物质，这可能是由低温火山或间歇泉喷发出来的
+        @PoltaInSpaceLow = 仪器检测到了一个紫外线特征，这可能表明表面同时存在氯和硅酸盐
+        @PoltaInSpaceLow = Polta确实有很多冰
+
+        @NeidonInSpace = 一些条带在紫外线下发光，提供了一些关于其化学组成的线索
+        @NeidonInSpaceHigh = 紫外图像显示甲烷在南半球较高海拔处更为普遍
+        @NeidonInSpaceHigh = Neidon的极地下方的条带看起来发出更多的紫外线光
+        @NeidonInSpaceLow = 近距离紫外线发射测量用于制作Neidon的增强彩色图像
+
+        @ThatmoInSpaceHigh = Thatmo的大气被发现非常稀薄，甚至比Duna的还要淡
+        @ThatmoInSpaceHigh = 仪器检测到主要由氮气组成的成分
+        @ThatmoInSpaceLow = 在非常明亮和反射性的氮冰表面上，近距离紫外线分析效果较差
+        @ThatmoInSpaceLow = Thatmo继续以其明亮的冰和活跃的地质现象令人惊叹。光谱还检测到了低温火山口附近的甲烷
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_solarWind]]:AFTER[CoatlAerospace]
+{
+    @title = 太阳风分析
+    @RESULTS
+    {
+        @default = 您测量了太阳风粒子的强度和方向
+        @default = 在此高度测量了Kerbol的太阳风
+        @default = 计算机记录了太阳风数据
+
+        @SunInSpace = 太阳风从Kerbol螺旋向外，可能沿着其磁力线
+        @SunInSpace = 在仪器进入安全模式之前记录了振荡测量值
+        @SunInSpaceLow = 从日冕洞中检测到了非常强烈的太阳风喷流
+        @SunInSpaceLow = 太阳风测量显示这里的风速低于接近Kerbin时的速度
+        @SunInSpaceHigh = 记录了太阳风测量值
+        @SunInSpaceHigh = 在KSC科学家激烈争论应称为太阳风速度还是太阳风速率的同时记录了太阳风数据
+
+        @MohoInSpace = 太阳风稳定地轰击Moho的暴露表面
+        @MohoInSpaceLow = 尽管速度较低，太阳风对Moho仍有强烈影响
+        @MohoInSpaceHigh = Moho附近存在大量不规则的太阳风活动
+
+        @EveInSpace = Eve对太阳风方向有明显的影响
+        @EveInSpaceLow = 尽管行为不稳定，Eve似乎偏转了相当一部分太阳风
+        @EveInSpaceHigh = 靠近Kerbol时，太阳风方向变得更加混乱
+
+        @GillyInSpace = 偏转和直接的太阳风排放清楚地到达了Gilly的表面
+        @GillyInSpaceLow = Gilly被Eve偏转的太阳风击中
+        @GillyInSpaceHigh = Gilly的测量在此高度没有提供明确的数据
+
+        @KerbinInSpace = 记录了来自Kerbin周围的太阳风速度和强度
+        @KerbinInSpaceLow = Kerbol的太阳风排放显然与Kerbin的大气层相互作用
+        @KerbinInSpaceHigh = 记录了风速以与其他行星进行比较
+        @KerbinInSpaceHigh = 太阳风不知为何被Kerbin偏转。科学家建议将其与磁强计结果进行比较
+
+        @MunInSpace = 记录了Mun周围的太阳风水平
+        @MunInSpaceLow = 看起来没有任何风偏转，因此Mun直接受到太阳风的轰击
+        @MunInSpaceHigh = 表面粒子似乎被吹入太空
+
+        @MinmusInSpace = 仪器从Minmus周围取样
+        @MinmusInSpaceLow = 太阳风检测显示Minmus也直接受到轰击
+        @MinmusInSpaceHigh = 太阳风分析完成：青柠
+
+        @DunaInSpace = 仪器从Duna周围取样
+        @DunaInSpaceLow = 跟踪太阳风方向显示至少有一部分偏转并到达下层大气
+        @DunaInSpaceHigh = 测量到的太阳风足够强，可以将Duna表面顶部的轻质粒子吹走
+
+        @DresInSpace = 记录了结果。太阳风直接轰击Dres的表面
+        @DresInSpaceLow = 太阳风速度测量表明，随着距离Kerbol的增加，风速实际上在加速
+        @DresInSpaceHigh = *静电*
+        @DresInSpaceHigh = 仍然可以在Dres周围清晰检测到Kerbol的太阳风
+
+        @JoolInSpace = Jool的干扰阻止了明确的结果
+        @JoolInSpaceLow = 太阳风似乎不对Jool的深层磁层产生影响
+        @JoolInSpaceHigh = 检测到太阳风与Jool的上层磁层相互作用
+        @JoolInSpaceHigh = Jool对太阳风方向有显著影响
+
+        @LaytheInSpace = Laythe被检测到有一个磁鞘偏转太阳风等离子体，还受到Jool引力的影响
+        @LaytheInSpaceLow = 检测到等离子体电离，Laythe必须含有电离层
+        @LaytheInSpaceHigh = 由于其靠近Jool，Laythe与许多被Jool偏转的太阳粒子相互作用
+
+        @VallInSpace = 没有等离子体相互作用，表明Vall周围没有大气层
+        @VallInSpaceLow = KSC将旋钮调至11。再次检测到太阳风
+        @VallInSpaceHigh = 未检测到太阳风。我们是否已经离开了Kerbol系统？
+
+        @PolInSpace = 收到了来自Pol的分析
+        @PolInSpaceLow = 分析表明此处检测到的太阳风是被Jool偏转过来的
+        @PolInSpaceHigh = 系统检测到接近Pol时风活动增加
+
+        @TyloInSpace = 结果使科学家们思考Tylo的大气层发生了什么
+        @TyloInSpaceLow = 尽管Tylo有磁鞘，但似乎没有太阳风相互作用或大气层
+        @TyloInSpaceHigh = 看起来太阳风粒子被Tylo的引力偏转
+
+        @BopInSpace = 数据确认Jool有一个大型磁层，影响其周围的风模式
+        @BopInSpaceLow = Jool的巨大引力将太阳风粒子偏转到Bop的路径上和周围
+        @BopInSpaceHigh = 在Bop上方这个纬度检测到的太阳风呈现出非常不规则的模式
+
+        @EelooInSpace = 从Eeloo收集了数据
+        @EelooInSpaceLow = 太阳风在这里的速度是接近Kerbin时的两倍
+        @EelooInSpaceHigh = 可检测到的少量太阳风速度非常快！
+
+        // OPM
+
+        @SarnusInSpaceLow = 太阳风测量确认Sarnus大部分被太阳粒子屏蔽
+        @SarnusInSpaceHigh = 太阳粒子被偏转和扰乱，可能是由行星的强大磁场引起的
+        @SarnusInSpaceHigh = 检测到太阳风与Sarnus的外层磁层相互作用
+
+        @TektoInSpace = Tekto在其母星的保护下相对较好地屏蔽了太阳粒子
+        @TektoInSpace = 检测到的粒子似乎被Sarnus的磁场偏转
+
+        @SlateInSpaceHigh = 结果使科学家们思考Slate的大气层发生了什么
+        @SlateInSpaceHigh = 这么远的距离仍能清晰检测到Kerbol的排放
+        @SlateInSpaceLow = 表面粒子似乎被吹入太空
+
+        @HaleInSpace = Sarnus的环状物干扰导致无法得出明确结论
+        @HaleInSpaceLow = 月球被气体巨行星的强大磁层深深屏蔽
+
+        @OvokInSpace = 在Ovok附近收集了数据
+        @OvokInSpace = 太阳风在这里的速度是接近Kerbin时的两倍
+
+        @UrlumInSpaceLow = Urlum的磁层强大到足以屏蔽大部分太阳等离子体
+        @UrlumInSpaceHigh = 太阳粒子显然被行星的磁场偏转
+        @UrlumInSpaceHigh = 测量到的太阳等离子体偏转似乎表明沿Urlum磁尾呈扭曲旋转
+
+        @WalInSpaceHigh = Urlum测量结果显示它提供了一些太阳风屏蔽
+        @WalInSpaceLow = 太阳风分析完成：香蕉
+
+        @TalInSpace = 太阳风分析完成：木薯粉
+        @TalInSpace = 即使在这个距离上，仪器仍能感受到Kerbol太阳粒子排放的影响
+
+        @PriaxInSpace = 测量提供了更清晰的Urlum磁层图，但未显示与小卫星的显著相互作用
+        @PriaxInSpaceLow = 尽管有Urlum的磁保护，Priax仍暴露于一些太阳风侵蚀
+
+        @PoltaInSpace = 尽管有Urlum的磁保护，Polta仍暴露于一些太阳风侵蚀
+        @PoltaInSpace = 太阳风在这里的速度是接近Kerbin时的两倍
+
+        @NeidonInSpaceLow = Neidon复杂的磁场对传入的太阳风产生了有趣的影响，尽管它们仍然被很好地偏转
+        @NeidonInSpaceHigh = 检测到太阳风与Neidon的上层磁层相互作用
+
+        @ThatmoInSpaceHigh = 测量到的太阳风似乎正在侵蚀Thatmo上层大气的一小部分
+        @ThatmoInSpaceLow = Thatmo的逆行轨道在Neidon磁层内的太阳风活跃区域划出了一条有趣的路径
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_kdex]]:AFTER[CoatlAerospace]
+{
+    @title = 空间粉尘分析
+    @RESULTS
+    {
+        @default = 碰撞的颗粒似乎非常小
+        @InSpace = 灰尘形成一个煎饼状的云层。这可能会导致反光
+
+        @KerbinSrfLandedLaunchpad = 进入的颗粒由燃烧的火箭燃料粒子组成
+        @KerbinSrfLandedRunway = 灰尘似乎由污染颗粒组成
+        @KerbinSrfLandedKSC = 有证据表明灰尘由花粉、坎巴拉人的毛发和太空服纤维组成
+        @KerbinFlyingLowGrasslands = 颗粒密度似乎与花粉相同。阿嚏！
+        @KerbinFlyingLowDeserts = 许多碰撞，相当多尘的地方
+        @KerbinFlyingLowBadlands = 与我们书架上的灰尘相同
+        @KerbinFlyingLowShores = 松散的颗粒材料。可能与覆盖Kerbin海滩、河床和沙漠的物质相同
+        @KerbinFlyingLowIceCaps = 即将进入带有复杂光谱特征的灰尘
+        @KerbinInSpaceLow = 我们发现了极其细小的矿物灰尘颗粒的证据
+        @KerbinInSpaceLow = 上面有不同的灰尘。它似乎形成了某种形状
+        KerbinFlyingLowWater = 偶尔检测到的微小矿物质颗粒可能是来自附近陆地或河流携带的沉积物。
+        KerbinFlyingLowTundra = 有机物和矿物质的组合反映了该地区的自然环境。
+
+        @MunInSpaceHigh = 这种灰尘不像滑石粉。它很险恶。它沿着电场线移动，会进入到设备中.
+        @MunInSpaceLow = 高密度！良好的撞击率。低高度的灰尘应该能够在日落时发光
+        @MunInSpaceLowTwinCraters = 每次颗粒碰撞后都跟着同电荷的碰撞
+        @MunInSpaceLowEastFarsideCrater = 较低的碰撞率，但撞击强烈
+        @MunInSpaceLowMidlandCraters = 较低的碰撞率和弱撞击
+        @MunInSpaceLowMidlands = 碰撞率和撞击处于平均水平
+        @MunInSpaceLowHighlands = 颗粒带有高电荷
+        @MunInSpaceLowPolarLowlands = 没有颗粒进入传感器。可能是太冷了
+        @MunInSpaceLowFarsideCrater = 几乎没有碰撞，弱撞击
+        @MunSrfLanded = 真相！月球外逸层含有由于静电悬浮的灰尘
+
+        @MinmusInSpaceHigh = 几乎没有撞击。密度低于水的密度。但高于我们食堂薄荷冰淇淋的密度
+        @MinmusInSpaceLowHighlands = 我们在离子化灰尘颗粒上发现了硫酸盐涂层
+        @MinmusInSpaceLowMidlands = 我们的仪器罐子看起来像薄荷圣代
+        @MinmusInSpaceLowLowlands = 这些结果表明沉积的颗粒与较高海拔处的颗粒成分不同
+        @MinmusInSpaceLowSlopes = 低水平灰尘
+        @MinmusInSpaceLowGreatFlats = 明显没有硫酸盐颗粒。表明缺乏人为污染
+        @MinmusInSpaceLowGreaterFlats = 含有石膏、石英、NaCl（可能是海盐或矿物岩盐）、富含钙的颗粒和钙碳酸盐的痕迹
+        @MinmusInSpaceLowLesserFlats = 中等强度的沙尘暴
+        @MinmusInSpaceLowFlats = 直径大于1微米的颗粒组成
+        @MinmusInSpaceLowPoles = 发现离子化灰尘颗粒上没有涂层
+
+        @GillyInSpaceLow = 带有硅酸盐核心的灰尘在仪器后面发生碰撞
+        @GillySrfLanded = 这些颗粒有一个由无定形碳组成的烟炱包层
+
+        @MohoInSpaceLow = 密度几乎与飞灰的密度一样高
+        @MohoSrfLanded = 细粉末由从亚微米到超过100微米大小的玻璃球组成。比重为1.9至2.4，体积密度为每立方米0.8-1吨
+
+        @EveInSpaceLow = 灰尘像玻璃一样。即将发生强烈的撞击
+        @EveFlying = 强烈的撞击和高碰撞率是对设备的极大考验
+
+        @DunaInSpaceLow = 进入的颗粒大小在几十分之一纳米到几微米之间变化
+        @DunaSrfLanded = 灰尘相当粗糙，显示出类似沙子的碰撞
+
+        @IkeInSpaceLow = 尘埃颗粒稀疏
+        @IkeSrfLanded = 只有少量灰尘颗粒进入传感器。我们应该带一把铲子
+
+        @DresInSpaceLow = 灰尘似乎由碳质、硅酸盐和金属颗粒组成
+        @DresSrfLanded = 灰尘如此密集以至于吸收并散射阳光
+
+        @JoolInSpaceLow = 没有灰尘或颗粒太小无法被仪器识别
+
+        @LaytheInSpaceLow = 灰尘试图形成形状。我们在Kerbin附近观察到了相同的行为
+        @LaytheSrfLanded = 松散的颗粒材料。可能由碳酸钙组成
+        @LaytheSrfSplashed = 没有颗粒进入传感器
+
+        @VallInSpaceLow = 灰尘试图形成形状。密度低于水
+        @VallSrfLanded = 寒冷似乎将灰尘颗粒困在表面上
+
+        @TyloInSpaceLow = 避免这个区域，只是很多灰尘和阻力，最终毫无意义
+        @TyloSrfLanded = 由于高重力，灰尘聚集成球
+
+        @BopInSpaceLow = 灰尘聚集形成致密的核心
+        @BopSrfLanded = 传感器中有太多灰尘
+
+        @PolInSpaceLow = 清除这里的灰尘会是一个好的开始
+        @PolSrfLanded = 弱撞击。可能是磷酸或硫酸来源
+
+        @EelooInSpaceLow = 灰尘颗粒稀疏
+        @EelooSrfLanded = 灰尘由一氧化碳、碳化硅、无定形硅酸盐和大量冰组成
+
+        // OPM
+
+        @SarnusInSpaceLow = 检测到非常小的颗粒，并且似乎是从环平面偏转而来
+        @SarnusInSpaceHigh = 似乎有一圈灰尘颗粒围绕着Sarnus
+
+        @TektoInSpace = 只检测到少量颗粒
+        @TektoInSpace = Tekto的倾角不允许它捕获许多环颗粒
+
+        @SlateInSpace = 进入的颗粒大小在几十分之一纳米到几微米之间变化
+        @SlateLanded = 寒冷似乎将灰尘颗粒困在表面上
+        @SlateLanded = 密度几乎与飞灰的密度一样高
+
+        @HaleInSpace = 进入的颗粒大小在几十分之一纳米到几微米之间变化
+        @HaleInSpacelow = 检测到的颗粒频率随着接近行星的环平面而迅速增加
+        @HaleLanded = 检测到的颗粒显然是来自环的材料，鉴于其靠近环
+
+        @OvokInSpace = 灰尘试图形成形状。密度低于水
+        @OvokLanded = 灰尘看起来是一种非常细且蓬松的材料。可能是雪...
+
+        @UrlumInSpace = 没有灰尘或颗粒太小无法被仪器识别
+        @UrlumInSpaceHigh = 检测到一些颗粒，可能是行星周围微弱环的一部分
+
+        @WalInSpace = 灰尘试图形成形状。我们在Kerbin附近观察到了相同的行为
+        @WalInSpace = 弱撞击。可能是磷酸或硫酸来源
+
+        @TalInSpace = 非常细微的撞击，可能是雪花
+        @TalInSpace = 在最高灵敏度下检测到细腻的粉末撞击
+
+        @PriaxInSpace = 检测到一些灰尘颗粒，可能是由Priax-Polta共振偏转而来
+        @PriaxInSpaceLow = 灰尘测量结果类似于我们预期的小行星周围的灰尘
+
+        @PoltaInSpace = 检测到一些灰尘颗粒，可能是由Priax-Polta共振偏转而来
+        @PoltaInSpaceLow = 非常细微的撞击，可能是雪花
+
+        @NeidonInSpace = 没有灰尘或颗粒太小无法被仪器识别
+        @NeidonInSpace = 灰尘颗粒稀疏
+
+        @ThatmoInSpaceHigh = 检测到微弱的雪状颗粒，可能是Thatmo的大气被吹走的结果
+        @ThatmoInSpaceLow = 冰，冰，宝贝！但可能不是香草。我们怀疑是氮
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_micrometeoroid]]:AFTER[CoatlAerospace]
+{
+    @title = 微流星体撞击数据
+    @RESULTS
+    {
+        @default = 一切都很安静。看起来什么都没发生——叮！
+        @default = 最近可能发生了撞击，但你没有注意到。
+        @default = 撞击器旁边的洞可能是测试结果，但你正忙着阻止爆炸性减压而无暇顾及。
+
+        @KerbinInSpaceLow = 撞击……谢天谢地，一切都还完好无损。看来航天器可以承受碎片撞击，但我们应该确保我们的飞船有防护措施。
+        @KerbinInSpaceLow = 当月亮像大比萨饼一样打到你的眼睛时……那就是撞击！
+        @KerbinInSpaceHigh = 自从进入更高轨道后，探测器记录的撞击次数减少了。
+
+        @MunInSpaceLow = 看起来Mun曾经有一个更小的卫星绕着它转——哦，它不见了。
+        @MunInSpaceHigh = 那些小小的叮当声？是的，那是你的科学结果宣布其到来的声音。
+
+        @MinmusInSpaceLow = 根据最近的撞击，你认为Minmus在向你发起雪球大战的挑战。
+        @MinmusInSpaceHigh = 这些微小的颗粒让你想起了冰淇淋上的糖霜……
+
+        @MohoInSpaceLow = Kerbol一定把一块岩石从Moho上炸飞了。
+        @MohoInSpaceHigh = 我们发现了一颗新天体绕着Moho运行，我们称之为Mohoteor……呃……它只存在了一瞬间。
+
+        @EveInSpaceLow = 哇！看起来探测器刚刚穿过了一个流星雨！
+        @EveInSpaceHigh = 紫色的星球，紫色的云，紫色的灰尘……他们在食物里放了什么？
+
+        @GillyInSpaceLow = 那可能是Gilly的更小的兄弟……
+        @GillyInSpaceHigh = 刚才撞到你的石头比Gilly小还是大？不确定……
+
+        @DunaInSpaceLow = 天哪！似乎你没预料到那次撞击……或者你预料到了？
+        @DunaInSpaceHigh = 看起来dunaroids就像其他任何流星体一样。坚硬如石，随时准备对你造成致命一击。
+
+        @IkeInSpaceLow = 你问Wehrner那是不是著名的魔法巨石……至少是一部分。
+        @IkeInSpaceHigh = 好吧，Ike在这里，但我没看到Mike。探测器上的那个污迹是什么？
+
+        @DresInSpaceLow = 你在到达Dres后不久就停止了计数撞击次数。
+        @DresInSpaceHigh = 如果Dres不是故意要杀你，为什么有42个船体补丁却没有探测器上的撞击记录？
+
+        @JoolInSpaceLow = 看起来所有的小碎片轨道早已衰减进了气态巨行星——叮！
+        @JoolInSpaceHigh = 显然，即使是这里的粒子也更大……
+
+        @LaytheInSpaceLow = 那次撞击显得特别……湿润。
+        @LaytheInSpaceHigh = 看来Laythe正式对你的探测器打了个喷嚏。恭喜你首次发现了太空鼻涕！
+
+        @VallInSpaceLow = 又一次撞击……所以呢？
+        @VallInSpaceHigh = 在637-K区域，颗粒细小且粗糙，但在这里它们更粗。我想我们找到了……泥土！
+
+        @TyloInSpaceLow = 设备测量到一次大的撞击，随后是许多小的撞击。
+        @TyloInSpaceHigh = 那声音并不是撞击造成的，而是直接由太空食品引起的。哐！这才是一次撞击！
+
+        @BopInSpaceLow = 飞行，任务控制中心。你并没有真的与Bop相撞。
+        @BopInSpaceHigh = 任务控制中心，飞行。我们刚才是不是撞上了Bop？
+
+        @PolInSpaceLow = 根据撞击情况判断，我们可能撞击到了某种晶体物质。
+        @PolInSpaceHigh = Pol礼貌地、恰当地预测并记录了撞击原则。
+
+        @EelooInSpaceLow = 即使在这里，航天器似乎也必须应对太空碎片。
+        @EelooInSpaceHigh = 我们来了，我们看到了，我们被更多的石头击中了。
+
+        @AsteroidInSpaceLow = 小行星周围的活动似乎导致了一些碎片脱落……
+        @AsteroidInSpaceHigh = 等等！没人说过岩石周围还有岩石。
+        @AsteroidSrfLanded = 探测器愤怒地发出警报，因为它被着陆时产生的碎片击中。
+
+        // 外行星模组
+
+        @SarnusInSpace = 检测到撞击，可能是偏转的环状颗粒
+        @SarnusInSpaceLow = 是的，Sarnus有行星环
+
+        @TektoInSpace = 仪器记录了一次撞击，结果是飞船打了个哈欠
+        @TektoInSpace = 在这个高度检测到的少量撞击非常微小。看来很少有环状颗粒被偏转到这里
+
+        @SlateInSpaceHigh = 检测到撞击，可能是偏转的环状颗粒
+        @SlateInSpaceLow = Slate缓慢地释放滑溜溜的冰粒，慢慢地滑入实验装置的槽中
+
+        @HaleInSpaceHigh = 检测到撞击，可能是偏转的环状颗粒
+        @HaleInSpaceLow = Hale记录的撞击感觉很像家里的冰雹
+        @HaleInSpaceLow = 当飞船接近环平面时，仪器记录的撞击声像是微波炉里爆米花的声音
+
+        @OvokInSpace = 又一次撞击……所以呢？
+        @OvokInSpace = 即使在这里，航天器似乎也必须应对太空碎片
+
+        @UrlumInSpace = 看起来所有的小碎片轨道早已衰减进了气态巨行星——叮！
+        @UrlumInSpace = 那次撞击显得特别冷
+
+        @WalInSpace = 记录了一次微小的冰撞击
+        @WalInSpace = 一切都很安静。看起来没什么会撞击
+
+        @TalInSpace = 记录了一次微小的冰撞击
+        @TalInSpace = 没有数据也是好数据，对吧？
+
+        @PriaxInSpace = 又一次撞击……所以呢？
+        @PriaxInSpace = 探测器要么刚刚穿过了一次流星雨，要么休息室里的爆米花好了
+
+        @PoltaInSpace = 记录了一次微小的冰撞击
+        @PoltaInSpace = 探测器记录了一些微小的颗粒，但大部分时间都很安静
+
+        @NeidonInSpace = 看起来所有的小碎片轨道早已衰减进了气态巨行星——叮！
+        @NeidonInSpace = 根据那次撞击判断，我们可能撞击到了某种晶体物质
+
+        @ThatmoInSpaceHigh = 探测器可能检测到了来自Thatmo附近的冰晶撞击
+        @ThatmoInSpaceLow = 这个区域似乎没有可检测到的微流星体
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[ca_SiteSurvey]]:AFTER[CoatlAerospace]
+{
+    @title = 地点勘测成像
+    @RESULTS
+    {
+        @default = 地点勘测完成
+        @default = 完成着陆点照片拍摄
+        @default = 发送着陆点照片以供分析
+
+        @MohoSrfLanded = 这不是着陆支架在融化吧？
+        @MohoSrfLanded = Moho的撞击坑比我们预期的少。相对平滑的表面应该对未来的着陆是安全的。
+        @MohoSrfLandedNorthPole = 哇！那是表面的一个洞吗？看起来不安全。
+
+        @EveSrfLanded = Eve的地貌似乎足够安全可以着陆，但不足以再次起飞。
+        @EveSrfLanded = 带着爱意从Eve发送的照片。
+        @EveSrfSplashed = 在确定这种液体的安全性之前，我们需要进行化学分析。
+        @EveSrfSplashed = 在这里着陆可能会使再次离开变得更加困难。
+            @GillySrfLanded = Gilly的表面主要平滑，只有少量散落的小石块。
+            @GillySrfLanded = 看着照片上的石头几乎让它们进入逃逸轨道。
+
+        @KerbinSrfLanded = Kerbin看起来足够安全，可以让乘员在不穿太空服的情况下着陆。
+        @KerbinSrfSplashed = 飞船需要既具有浮力又防水才能在这里着陆。
+        @KerbinSrfLandedKSC = 摄像头捕捉到许多实习生和测试者围聚在一起盯着飞船看。
+            @MunSrfLanded = Mun的众多陨石坑造成了高度变化，这对载人着陆具有挑战性，并且当太阳位于地平线附近时会在太阳能板上投下阴影。
+            @MunSrfLanded = 这些来自表面的图像拼接图将在社交媒体上获得大量点赞。
+
+            @MinmusSrfLanded = 科学家看着灰色的表面认为我们降落在了错误的卫星上。工程师告诉他们相机不能拍摄彩色照片。
+            @MinmusSrfLanded = 图像显示了许多大山丘，这些角度对降落来说很尴尬，但也有一些大的平坦光滑区域。
+        
+        @DunaSrfLanded = 没有看到外星人。谁修建了那些运河？
+        @DunaSrfLanded = 表面看起来非常尘土飞扬，但地形着陆对于小绿人们来说似乎是安全的。
+            @IkeSrfLanded = 我们喜欢Ike。非常"岩石"的表面，有许多小石块可供采样。
+        
+        @DresSrfLanded = 着陆点非常类似Mun但尘土较少。KSC认为它对小绿人的任务来说虽然安全，但很无聊。
+        @DresSrfLanded = 图像显示了许多可能妨碍安全载人着陆的山丘。Valentina愿意在那里着陆。
+
+        @JoolSrfLanded = 如果着陆器能安全到达，那么小绿人也应该可以，对吧？
+            @LaytheSrfLanded = 太多水了！需要小心规划轨迹以确保在地面着陆。
+            @LaytheSrfLanded = Laythe看起来像是一个完美的度假胜地！夏天！海滩！还有可供呼吸的空气！
+            @LaytheSrfSplashed = 太多水了！未来的航天器应该具备防水能力和浮力。
+
+            @VallSrfLanded = 地形非常不均匀，有些高耸相连的山脊可能是板块活动的迹象。
+            @VallSrfLanded = 不均匀的地形对载人着陆来说是个挑战。务必派遣经验丰富的飞行员。
+
+            @TyloSrfLanded = 表面非常像岩石，还有一些不均匀的地形和较大的地势起伏。
+
+            @BopSrfLanded = 对Bop有趣且非常不规则的地形分析因有人声称看到了触手而受到影响。
+            @BopSrfLanded = 一些穿黑色西装、戴帽子和墨镜的人在我们能够分析之前拿走了一张勘测照片，说了一些关于行星安全的事情。
+
+            @PolSrfLanded = 表面非常不规则且尖锐。有很多山脉和不均匀的山谷。已经为航天员准备了足够燃料以找到安全的着陆点
+
+        @EeelooSrfLanded = Eeloo的表面相对平滑。表面的高反射性证实了Eeloo的表面由冰层覆盖。乘员应该携带滑冰鞋。
+
+
+    }
+}


### PR DESCRIPTION
翻译了Coatlspace模组的部件名和描述、科学报告等。
汉化补丁有原版环境和RO环境两种，在非RO环境下，仅加载前者补丁；
两者补丁的区别在于RO补丁会将部件名改为现实中航天器的名字（例如子午线号在RO环境下名为卡西尼号）
Coatlspace：是一个部件扩展模组，为游戏添加现实中的探测器（如旅行者号、卡西尼号、水手号和朱诺号等）。